### PR TITLE
feat: ソースファイルの保存パスをセッションID基準に変更

### DIFF
--- a/openspec/changes/save-original-source-file/.openspec.yaml
+++ b/openspec/changes/save-original-source-file/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-08

--- a/openspec/changes/save-original-source-file/design.md
+++ b/openspec/changes/save-original-source-file/design.md
@@ -1,0 +1,53 @@
+## Context
+
+現在の管理機能（AdminPage）では、Teams出席レポートCSVをアップロードすると以下の3つの書き込みが実行される：
+
+1. `raw/{timestamp}-{filename}.csv` — 元CSVファイル（Fileオブジェクトをそのまま保存）
+2. `data/sessions/{sessionId}.json` — 変換後のセッションデータ
+3. `data/index.json` — ダッシュボード用インデックスの更新
+
+このうち、1番の保存パスがタイムスタンプ＋元ファイル名ベースであるため、どのセッションに対応するファイルか特定しにくい。セッションIDベースのパスに変更して追跡可能性を向上させる。
+
+変更対象は `AdminPage.jsx` の `handleBulkSave` 関数内で `rawCsv.path` を組み立てている1箇所のみ。`BlobWriter` 自体は汎用的な書き込み処理であり、パスを受け取って保存するだけなので変更不要。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- ソースCSVの保存パスを `data/sources/{sessionId}.csv` に変更し、セッションJSONと一対一で対応させる
+- 既存の `BlobWriter` のインターフェースを維持しつつ、パス変更のみで対応する
+
+**Non-Goals:**
+
+- 既に `raw/` に保存済みのファイルの移行・削除は行わない
+- ソースファイルの閲覧・ダウンロード UI は本変更のスコープ外
+- CSVの変換ロジック（`CsvTransformer`）への変更は行わない
+
+## Decisions
+
+### 1. 保存パスの命名規則: `data/sources/{sessionId}.csv`
+
+**選択**: `data/sources/{sessionId}.csv`
+
+**理由**:
+- セッションJSON（`data/sessions/{sessionId}.json`）と同じID体系で対応するため、紐づけが明確
+- `data/` 配下に統一することで、データの論理的な構造が一貫する
+- sessionId はハッシュベースで一意性が保証されている
+
+**代替案**:
+- `raw/{sessionId}.csv` — `raw/` ディレクトリを継続使用する案。しかし `data/` 配下に統一した方がデータ構造として整合的
+- `data/sessions/{sessionId}.csv` — sessions と同じディレクトリに置く案。JSON と CSV が混在し、管理が煩雑になるため不採用
+
+### 2. 変更箇所の最小化
+
+**選択**: `AdminPage.jsx` の `handleBulkSave` 内のパス文字列のみ変更
+
+**理由**:
+- `BlobWriter.executeWriteSequence` はパスを引数として受け取る汎用的な設計であり、内部の変更は不要
+- `CsvTransformer` は CSV パースのみを担当し、保存先に関与しない
+- タイムスタンプ生成コード（`new Date().toISOString().replace(...)`)は不要になるため削除
+
+## Risks / Trade-offs
+
+- **同一セッションの再アップロード**: 同じ勉強会・同じ日付のCSVを再アップロードした場合、同じ sessionId が生成されるため `data/sources/{sessionId}.csv` が上書きされる。ただし、セッションJSON（`data/sessions/{sessionId}.json`）も同様に上書きされるため、整合性は維持される。→ 既存の重複検出（`duplicate_warning` ステータス）で事前に警告されるため、実運用上の問題は小さい
+- **既存 `raw/` データとの不整合**: 移行を行わないため、過去のデータは `raw/` に残り続ける。→ 新規アップロード分から `data/sources/` に保存されるため、段階的に移行される。必要に応じて手動で移行可能

--- a/openspec/changes/save-original-source-file/proposal.md
+++ b/openspec/changes/save-original-source-file/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+管理機能でTeams出席レポートCSVをアップロードすると、現在は `raw/{timestamp}-{filename}.csv` というタイムスタンプベースのパスで元ファイルが保存されている。しかし、このパス命名ではどのセッションに対応するファイルなのかが分かりにくく、後から特定のセッションの元データを参照・再検証する際に不便である。ソースファイルをセッションIDと紐づけた形で保存することで、データの追跡可能性と管理性を向上させる。
+
+## What Changes
+
+- アップロードされたCSVファイルの保存パスを `raw/{timestamp}-{filename}.csv` から `data/sources/{sessionId}.csv` に変更し、セッションIDと紐づけて保存する
+- これにより、各セッションの変換後JSON（`data/sessions/{sessionId}.json`）と元CSV（`data/sources/{sessionId}.csv`）が一対一で対応する構造になる
+- 既存の `raw/` ディレクトリへの保存は廃止する
+
+## Capabilities
+
+### New Capabilities
+
+- `original-source-storage`: アップロードされたCSVソースファイルをセッションIDと紐づけて `data/sources/` に保存する機能
+
+### Modified Capabilities
+
+（なし — openspec/specs/ に既存の仕様なし）
+
+## Impact
+
+- **blob-writer.js**: 書き込みシーケンスの `rawCsv` パス生成ロジックを変更
+- **AdminPage.jsx**: `handleBulkSave` 内の `rawCsv.path` をセッションIDベースに変更
+- **Azure Blob Storage**: `data/sources/` ディレクトリが新設される。既存の `raw/` ディレクトリは今後使用されなくなる
+- **既存データ**: 既にアップロード済みの `raw/` 内ファイルには影響なし（移行不要）

--- a/openspec/changes/save-original-source-file/specs/original-source-storage/spec.md
+++ b/openspec/changes/save-original-source-file/specs/original-source-storage/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: ソースCSVファイルのセッションID紐づけ保存
+管理機能でTeams出席レポートCSVをアップロードした際、システムはオリジナルのCSVファイルを `data/sources/{sessionId}.csv` パスに保存しなければならない（SHALL）。sessionId はCSV変換処理で生成されるセッションIDと同一のものを使用しなければならない（MUST）。
+
+#### Scenario: 正常なCSVアップロード時のソースファイル保存
+- **WHEN** 管理者が有効なTeams出席レポートCSVをアップロードし一括保存を実行する
+- **THEN** システムはオリジナルのCSVファイルを `data/sources/{sessionId}.csv` に保存する
+- **THEN** 保存されるファイルの内容はアップロードされたファイルと完全に同一である
+
+#### Scenario: 複数ファイルの一括アップロード時
+- **WHEN** 管理者が複数のCSVファイルを一括アップロードし保存を実行する
+- **THEN** 各CSVファイルがそれぞれのセッションIDに対応する `data/sources/{sessionId}.csv` に保存される
+
+### Requirement: セッションデータとソースファイルの一対一対応
+各セッションの変換後JSON（`data/sessions/{sessionId}.json`）とソースCSV（`data/sources/{sessionId}.csv`）は同一のセッションIDで一対一に対応しなければならない（MUST）。
+
+#### Scenario: セッションJSONとソースCSVの対応関係
+- **WHEN** CSVファイルのアップロードと保存が正常に完了した場合
+- **THEN** `data/sessions/{sessionId}.json` と `data/sources/{sessionId}.csv` が同一の sessionId で存在する
+
+### Requirement: rawディレクトリへの保存廃止
+システムは `raw/{timestamp}-{filename}.csv` パスへのファイル保存を行わないようにしなければならない（MUST）。タイムスタンプベースのパス生成ロジックは削除する。
+
+#### Scenario: アップロード時にrawディレクトリへ保存されない
+- **WHEN** 管理者がCSVファイルをアップロードし一括保存を実行する
+- **THEN** `raw/` ディレクトリへのファイル書き込みは発生しない
+- **THEN** ソースファイルは `data/sources/` ディレクトリにのみ保存される

--- a/openspec/changes/save-original-source-file/tasks.md
+++ b/openspec/changes/save-original-source-file/tasks.md
@@ -1,0 +1,9 @@
+## 1. ソースファイル保存パスの変更
+
+- [x] 1.1 `AdminPage.jsx` の `handleBulkSave` 内で `rawCsv.path` を `raw/${timestamp}-${item.file.name}` から `data/sources/${sessionRecord.id}.csv` に変更する
+- [x] 1.2 `AdminPage.jsx` の `handleBulkSave` 内で不要になった `timestamp` 変数（`const timestamp = new Date().toISOString().replace(/[:.]/g, '-');`）を削除する
+
+## 2. テスト
+
+- [x] 2.1 `AdminPage.jsx` の変更に対する既存テストが通ることを確認する（`pnpm test`）
+- [x] 2.2 `handleBulkSave` で `blobWriter.executeWriteSequence` に渡される `rawCsv.path` が `data/sources/{sessionId}.csv` 形式であることを検証するテストを追加する

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -61,11 +61,10 @@ export function AdminPage() {
       setSaveStatusText(`保存中... ${item.file.name}`);
 
       const { sessionRecord, mergeInput } = item.parseResult;
-      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 
       const result = await blobWriter.executeWriteSequence({
         rawCsv: {
-          path: `raw/${timestamp}-${item.file.name}`,
+          path: `data/sources/${sessionRecord.id}.csv`,
           content: item.file,
           contentType: 'text/csv',
         },

--- a/tests/react/pages/AdminPage.test.jsx
+++ b/tests/react/pages/AdminPage.test.jsx
@@ -1,0 +1,110 @@
+// AdminPage — ソースファイル保存パスの検証テスト
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AdminPage } from '../../../src/pages/AdminPage.jsx';
+
+// BlobWriter のモック — executeWriteSequence の引数をキャプチャ
+const mockExecuteWriteSequence = vi.fn().mockResolvedValue({ results: [], allSucceeded: true });
+
+vi.mock('../../../src/services/blob-writer.js', () => ({
+  BlobWriter: vi.fn().mockImplementation(() => ({
+    executeWriteSequence: mockExecuteWriteSequence,
+  })),
+}));
+
+// CsvTransformer のモック
+const mockParse = vi.fn();
+vi.mock('../../../src/services/csv-transformer.js', () => ({
+  CsvTransformer: vi.fn().mockImplementation(() => ({
+    parse: (...args) => mockParse(...args),
+  })),
+}));
+
+// IndexMerger のモック
+vi.mock('../../../src/services/index-merger.js', () => ({
+  IndexMerger: vi.fn().mockImplementation(() => ({
+    merge: vi.fn().mockReturnValue({
+      index: { studyGroups: [], members: [], updatedAt: '' },
+      warnings: [],
+    }),
+  })),
+}));
+
+// DataFetcher のモック
+vi.mock('../../../src/services/data-fetcher.js', () => ({
+  DataFetcher: vi.fn().mockImplementation(() => ({
+    fetchIndex: vi.fn().mockResolvedValue({
+      ok: true,
+      data: { studyGroups: [], members: [], updatedAt: '' },
+    }),
+  })),
+}));
+
+// useAuth のモック — 管理者として認証済み
+vi.mock('../../../src/hooks/useAuth.jsx', () => ({
+  useAuth: () => ({ sasToken: 'test-sas-token', isAdmin: true }),
+  createAuthAdapter: () => ({
+    getSasToken: () => 'test-sas-token',
+    isAdminMode: () => true,
+  }),
+}));
+
+describe('AdminPage — ソースファイル保存パス', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockParse.mockResolvedValue({
+      ok: true,
+      sessionRecord: {
+        id: 'abc12345-2026-02-08',
+        studyGroupId: 'abc12345',
+        date: '2026-02-08',
+        attendances: [{ memberId: 'mem001', durationSeconds: 3600 }],
+      },
+      mergeInput: {
+        sessionId: 'abc12345-2026-02-08',
+        studyGroupId: 'abc12345',
+        studyGroupName: 'テスト勉強会',
+        date: '2026-02-08',
+        attendances: [{ memberId: 'mem001', memberName: 'テスト太郎', durationSeconds: 3600 }],
+      },
+      warnings: [],
+    });
+  });
+
+  it('一括保存時にrawCsv.pathが data/sources/{sessionId}.csv 形式であること', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <AdminPage />
+      </MemoryRouter>
+    );
+
+    // CSVファイルを追加（input[type="file"] を直接操作）
+    const csvContent = new Blob(['dummy csv'], { type: 'text/csv' });
+    const file = new File([csvContent], 'test-report.csv', { type: 'text/csv' });
+    const fileInput = document.querySelector('input[type="file"]');
+    await user.upload(fileInput, file);
+
+    // パース完了後「一括保存」ボタンが表示されるまで待機
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /一括保存/ })).toBeInTheDocument();
+    });
+
+    // 一括保存ボタンをクリック
+    await user.click(screen.getByRole('button', { name: /一括保存/ }));
+
+    // BlobWriter.executeWriteSequence が呼ばれたことを確認
+    await waitFor(() => {
+      expect(mockExecuteWriteSequence).toHaveBeenCalled();
+    });
+
+    // rawCsv.path が data/sources/{sessionId}.csv 形式であることを検証
+    const callArgs = mockExecuteWriteSequence.mock.calls[0][0];
+    expect(callArgs.rawCsv.path).toBe('data/sources/abc12345-2026-02-08.csv');
+
+    // raw/ ディレクトリへのパスでないことを検証
+    expect(callArgs.rawCsv.path).not.toMatch(/^raw\//);
+  });
+});


### PR DESCRIPTION
## Summary
- アップロード時のrawCsv保存パスを `raw/{timestamp}-{filename}` から `data/sources/{sessionId}.csv` に変更
- タイムスタンプベースのファイル名を廃止し、セッションIDで一意に管理できるようにした
- AdminPage のテストを追加し、保存パスが正しい形式であることを検証

Closes #9

## Test plan
- [x] AdminPage.test.jsx のテストが通ることを確認
- [x] 管理画面からCSVアップロード→保存後、`data/sources/{sessionId}.csv` に保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)