### PR TITLE
用語変更: 学習時間→参加時間 & CLAUDE.md/AGENTS.md 改善

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
-# AI-DLC and Spec-Driven Development
+# AGENTS.md
 
-Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life Cycle)
+This file provides guidance when working with code in this repository.
+
+You are running on Windows. Bash isn't available directly, so please use Bash (via pwsh:*).
 
 ## Primary Directive
 
@@ -9,54 +11,93 @@ Kiro-style Spec Driven Development implementation on AI-DLC (AI Development Life
 - Class names, function names, and other identifiers must be written in English.
 - Can execute GitHub CLI/Azure CLI. Will execute and verify them personally
   whenever possible.
-- Do not modify files directly on the main branch. 
+- Do not modify files directly on the main branch.
 - Create a branch with an appropriate name and switch to it before making any modifications.
 
-## Project Memory
-Project memory keeps persistent guidance (steering, specs notes, component docs) so Codex honors your standards each run. Treat it as the long-lived source of truth for patterns, conventions, and decisions.
+## Common Commands
 
-- Use `.kiro/steering/` for project-wide policies: architecture principles, naming schemes, security constraints, tech stack decisions, api standards, etc.
-- Use local `AGENTS.md` files for feature or library context (e.g. `src/lib/payments/AGENTS.md`): describe domain assumptions, API contracts, or testing conventions specific to that folder. Codex auto-loads these when working in the matching path.
-- Specs notes stay with each spec (under `.kiro/specs/`) to guide specification-level workflows.
+```bash
+pnpm install              # Install dependencies
+pnpm run dev              # Start dev server (http://localhost:5173, with HMR)
+pnpm run build            # Production build (output to dist/)
+pnpm test                 # Run unit tests with Vitest
+pnpm run test:watch       # Vitest watch mode
+pnpm run test:coverage    # Run tests with coverage
+pnpm run lint             # ESLint static analysis
+pnpm run format           # Prettier code formatting
 
-## Project Context
+# E2E tests (Playwright)
+pnpm exec playwright install   # First time only: install browsers
+pnpm run test:e2e              # Headless execution
+pnpm run test:e2e:headed       # Run with browser visible
 
-### Paths
-- Steering: `.kiro/steering/`
-- Specs: `.kiro/specs/`
+# Run a single test file
+pnpm vitest run tests/logic/csv-transformer.test.js
+pnpm vitest run tests/react/pages/DashboardPage.test.jsx
+```
 
-### Steering vs Specification
+## Tech Stack
 
-**Steering** (`.kiro/steering/`) - Guide AI with project-wide rules and context
-**Specs** (`.kiro/specs/`) - Formalize development process for individual features
+- **React 19** + **Vite** — JSX (no TypeScript)
+- **react-router-dom** (HashRouter) — `#/` based routing
+- **Tailwind CSS 4** — Utility-first CSS
+- **PapaParse** — Teams attendance report CSV (UTF-16LE) parser
+- **Vitest** + **React Testing Library** — Unit tests in jsdom environment
+- **Playwright** — E2E tests (Chromium only)
+- **pnpm** — Package manager (`packageManager: pnpm@10.27.0`)
 
-### Active Specifications
-- Check `.kiro/specs/` for active specifications
-- Use `/prompts:kiro-spec-status [feature-name]` to check progress
+## Architecture
 
-## Development Guidelines
-- Think in English, generate responses in Japanese. All Markdown content written to project files (e.g., requirements.md, design.md, tasks.md, research.md, validation reports) MUST be written in the target language configured for this specification (see spec.json.language).
+A dashboard SPA that aggregates and visualizes Microsoft Teams attendance report CSVs. Hosted on Azure Blob Storage static site hosting, operating without a backend server.
 
-## Minimal Workflow
-- Phase 0 (optional): `/prompts:kiro-steering`, `/prompts:kiro-steering-custom`
-- Phase 1 (Specification):
-  - `/prompts:kiro-spec-init "description"`
-  - `/prompts:kiro-spec-requirements {feature}`
-  - `/prompts:kiro-validate-gap {feature}` (optional: for existing codebase)
-  - `/prompts:kiro-spec-design {feature} [-y]`
-  - `/prompts:kiro-validate-design {feature}` (optional: design review)
-  - `/prompts:kiro-spec-tasks {feature} [-y]`
-- Phase 2 (Implementation): `/prompts:kiro-spec-impl {feature} [tasks]`
-  - `/prompts:kiro-validate-impl {feature}` (optional: after implementation)
-- Progress check: `/prompts:kiro-spec-status {feature}` (use anytime)
+### Layer Structure
 
-## Development Rules
-- 3-phase approval workflow: Requirements → Design → Tasks → Implementation
-- Human review required each phase; use `-y` only for intentional fast-track
-- Keep steering current and verify alignment with `/prompts:kiro-spec-status`
-- Follow the user's instructions precisely, and within that scope act autonomously: gather the necessary context and complete the requested work end-to-end in this run, asking questions only when essential information is missing or the instructions are critically ambiguous.
+| Layer | Path | Responsibility |
+|-------|------|----------------|
+| Pages | `src/pages/` | Per-screen data fetching and display (Dashboard, MemberDetail, GroupDetail, Admin) |
+| Components | `src/components/` | Reusable UI parts (FileDropZone, GroupList, MemberList, SummaryCard, etc.) |
+| Hooks | `src/hooks/` | State management (`useAuth` = SAS token auth, `useFileQueue` = file queue) |
+| Services | `src/services/` | I/O and domain logic (see below) |
+| Config | `src/config/` | Environment variable based config (`APP_CONFIG.blobBaseUrl`) |
 
-## Steering Configuration
-- Load entire `.kiro/steering/` as project memory
-- Default files: `product.md`, `tech.md`, `structure.md`
-- Custom files are supported (managed via `/prompts:kiro-steering-custom`)
+### Services Layer Roles
+
+- **CsvTransformer** — Parses Teams attendance report CSV (UTF-16LE/TSV), producing session records and index merge inputs. Uses first 8 hex digits of SHA-256 for ID generation
+- **IndexMerger** — Immutably updates groups/members in `index.json` (duplicate sessionIds are skipped with warnings)
+- **DataFetcher** — Fetches `data/index.json` and `data/sessions/*.json` from the static site
+- **BlobWriter** — PUTs to Azure Blob Storage with SAS token
+
+### Routing
+
+- `#/` — Dashboard overview
+- `#/groups/:groupId` — Group detail
+- `#/members/:memberId` — Member detail
+- `#/admin` — Admin page (visible only when SAS token authenticated)
+
+### Data Flow
+
+- Read path: Static Website Endpoint → `data/index.json` (with cache buster) + `data/sessions/<id>.json` (immutable)
+- Write path: CSV drop → CsvTransformer → IndexMerger → BlobWriter (PUT with SAS)
+- SAS token is extracted from URL query `token` on first load, then immediately removed via `history.replaceState` and held in memory only
+
+### Development Data
+
+Development JSON fixtures are placed in `dev-fixtures/data/`. The Vite plugin `serveDevFixtures` (in vite.config.js) serves `/data/` requests from this directory on the dev server. Not included in `public/` since Azure Blob Storage serves this data in production.
+
+### Test Structure
+
+- `tests/data/` — DataFetcher, BlobWriter, IndexMerger tests
+- `tests/logic/` — CsvTransformer tests
+- `tests/react/` — React component, page, and hook tests
+- `tests/fixtures/` — Test CSV fixtures
+- `tests/vitest.setup.js` — webcrypto polyfill + jest-dom setup
+- `e2e/` — Playwright E2E tests (dashboard, admin)
+
+### CI/CD
+
+GitHub Actions (`.github/workflows/deploy.yml`) runs tests and lint in parallel on push, then deploys to Azure Blob Storage. `main` → prod environment, other branches → dev environment. Uses OIDC authentication.
+
+### Environment Variables (Build Time)
+
+- `VITE_APP_TITLE` — App title (default: 'Teams Board')
+- `VITE_BLOB_BASE_URL` — Blob Service Endpoint URL

--- a/e2e/dashboard.spec.js
+++ b/e2e/dashboard.spec.js
@@ -123,9 +123,9 @@ test.describe('グループ詳細画面', () => {
     await sessionHeadings.first().click();
     await expect(page.locator('table')).toBeVisible();
 
-    // テーブルに名前列と学習時間列がある
+    // テーブルに名前列と参加時間列がある
     await expect(page.getByRole('columnheader', { name: '名前' })).toBeVisible();
-    await expect(page.getByRole('columnheader', { name: '学習時間' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: '参加時間' })).toBeVisible();
 
     // 再クリックで折りたたみ
     await sessionHeadings.first().click();
@@ -172,9 +172,9 @@ test.describe('メンバー詳細画面 — グループ別表示', () => {
     await page.getByRole('heading', { name: 'フロントエンド勉強会' }).click();
     await expect(page.locator('table')).toBeVisible();
 
-    // テーブルに日付列と学習時間列がある
+    // テーブルに日付列と参加時間列がある
     await expect(page.getByRole('columnheader', { name: '日付' })).toBeVisible();
-    await expect(page.getByRole('columnheader', { name: '学習時間' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: '参加時間' })).toBeVisible();
 
     // 再クリックで折りたたみ
     await page.getByRole('heading', { name: 'フロントエンド勉強会' }).click();

--- a/src/components/FileQueueCard.jsx
+++ b/src/components/FileQueueCard.jsx
@@ -151,7 +151,7 @@ export function FileQueueCard({ item, onRemove, onApproveDuplicate }) {
                 <thead>
                   <tr className="border-b border-border-light text-text-secondary">
                     <th className="text-left py-2 px-3 font-medium">参加者</th>
-                    <th className="text-left py-2 px-3 font-medium">学習時間</th>
+                    <th className="text-left py-2 px-3 font-medium">参加時間</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-border-light">

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -55,15 +55,10 @@ export function DashboardPage() {
 
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="text-xl font-bold text-text-primary">学習サマリー</h2>
-        <p className="text-sm text-text-muted mt-1">全体の学習記録を確認できます</p>
-      </div>
-
       {/* 統計カード */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <SummaryCard
-          title="総勉強時間"
+          title="総参加時間"
           value={formatDuration(totalDuration)}
           icon={Clock}
         />

--- a/src/pages/GroupDetailPage.jsx
+++ b/src/pages/GroupDetailPage.jsx
@@ -199,7 +199,7 @@ export function GroupDetailPage() {
                       <thead>
                         <tr className="border-b border-border-light bg-surface-muted text-left text-sm text-text-secondary">
                           <th className="px-6 py-3 font-medium">名前</th>
-                          <th className="px-6 py-3 font-medium text-right">学習時間</th>
+                          <th className="px-6 py-3 font-medium text-right">参加時間</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-border-light">

--- a/src/pages/MemberDetailPage.jsx
+++ b/src/pages/MemberDetailPage.jsx
@@ -207,7 +207,7 @@ export function MemberDetailPage() {
                       <thead>
                         <tr className="border-b border-border-light bg-surface-muted text-left text-sm text-text-secondary">
                           <th className="px-6 py-3 font-medium">日付</th>
-                          <th className="px-6 py-3 font-medium text-right">学習時間</th>
+                          <th className="px-6 py-3 font-medium text-right">参加時間</th>
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-border-light">

--- a/tests/react/components/GroupList.test.jsx
+++ b/tests/react/components/GroupList.test.jsx
@@ -55,7 +55,7 @@ describe('GroupList', () => {
     }
   });
 
-  it('開催回数と学習時間が表示されること', () => {
+  it('開催回数と参加時間が表示されること', () => {
     renderGroupList();
 
     const rows = screen.getAllByTestId('group-row');

--- a/tests/react/components/MemberList.test.jsx
+++ b/tests/react/components/MemberList.test.jsx
@@ -41,7 +41,7 @@ describe('MemberList', () => {
       const rows = screen.getAllByTestId('member-row');
       const names = rows.map((row) => row.querySelector('h3').textContent);
 
-      // localeCompare('ja') でソートされること（勉強時間順ではないこと）
+      // localeCompare('ja') でソートされること（参加時間順ではないこと）
       expect(names[0]).toBe('Alice');
       expect(names[1]).toBe('Bob');
     });


### PR DESCRIPTION
## Summary
- UI全体で「学習時間」を「参加時間」に統一（DashboardPage, GroupDetailPage, MemberDetailPage, FileQueueCard）
- DashboardPage から不要な「学習サマリー」見出しセクションを削除
- CLAUDE.md / AGENTS.md をコマンド一覧・Tech Stack・アーキテクチャ解説付きに改善し、旧 AI-DLC セクションを削除
- 関連するユニットテスト・E2Eテストの文言を更新

## Test plan
- [ ] `pnpm test` で全ユニットテストがパスすること
- [ ] `pnpm run lint` でエラーがないこと
- [ ] `pnpm run test:e2e` でE2Eテストがパスすること
- [ ] UI上で「参加時間」と表示されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)