### PR TITLE
Fix docs deploy when GitHub Pages is disabled

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -121,6 +121,33 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: GitHub Pages 有効化状態を確認
+        id: pages-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.repos.getPages({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              core.setOutput('enabled', 'true');
+            } catch (error) {
+              if (error.status === 404) {
+                core.warning('GitHub Pages が未設定のため deploy-github-pages をスキップします。');
+                core.setOutput('enabled', 'false');
+                return;
+              }
+              throw error;
+            }
+
       - name: GitHub Pages へデプロイ
         id: deployment
+        if: steps.pages-check.outputs.enabled == 'true'
         uses: actions/deploy-pages@v4
+
+      - name: スキップ結果を記録
+        if: steps.pages-check.outputs.enabled != 'true'
+        run: |
+          echo "## GitHub Pages デプロイスキップ" >> "$GITHUB_STEP_SUMMARY"
+          echo "GitHub Pages が未設定のため、このジョブはスキップしました。" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 概要
Deploy Site の deploy-github-pages が、GitHub Pages 未設定リポジトリで 404 失敗する問題を修正します。

## 変更内容
- deploy-github-pages ジョブ先頭で epos.getPages により Pages 有効化状態を確認
- Pages 未設定（404）の場合は ctions/deploy-pages を実行せずスキップ
- スキップ時は GITHUB_STEP_SUMMARY に理由を出力

## 背景
Issue #50 実装後の push: main 実行（2026-02-13）で、
docs-site-deployment は成功したものの deploy-github-pages が 404 で失敗していました。

## 確認
- pnpm run lint
