### PR TITLE
ci: GitHub Actionsランナーを blacksmith-4vcpu-ubuntu-2404 に変更

### DIFF
--- a/.github/workflows/app-deployment.yml
+++ b/.github/workflows/app-deployment.yml
@@ -47,7 +47,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,7 +64,7 @@ jobs:
 
   test:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,7 +82,7 @@ jobs:
   build:
     name: Build
     needs: [lint, test]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:
@@ -117,7 +117,7 @@ jobs:
   deploy:
     name: Deploy App
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     environment: ${{ github.event_name == 'pull_request' && 'dev' || 'prod' }}
     permissions:
       contents: read
@@ -171,7 +171,7 @@ jobs:
     name: E2E Tests
     needs: deploy
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docs-deployment.yml
+++ b/.github/workflows/docs-deployment.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   lint:
     name: Text Lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
 
@@ -53,7 +53,7 @@ jobs:
   build:
     name: Build Docs
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       IS_PRODUCTION: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     steps:
@@ -116,7 +116,7 @@ jobs:
     name: Deploy SWA
     needs: build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write
@@ -142,7 +142,7 @@ jobs:
     name: Deploy GitHub Pages
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/preview-environment-cleanup.yml
+++ b/.github/workflows/preview-environment-cleanup.yml
@@ -15,7 +15,7 @@ jobs:
   close-preview:
     name: Close Preview
     if: github.event.pull_request.base.ref == 'main'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: プレビュー環境のクローズ（対象なしでも続行）
         continue-on-error: true


### PR DESCRIPTION
## Summary
- 全ワークフロー（app-deployment, docs-deployment, preview-environment-cleanup）の `runs-on` を `ubuntu-latest` から `blacksmith-4vcpu-ubuntu-2404` に変更（全10ジョブ）

## Test plan
- [ ] app-deployment ワークフローが正常に動作すること
- [ ] docs-deployment ワークフローが正常に動作すること
- [ ] preview-environment-cleanup ワークフローが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)