### PR TITLE
feat: CSV登録時にグループ名をプルダウンで選択可能にする

### DIFF
--- a/openspec/changes/archive/2026-02-14-csv-group-selector/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-14-csv-group-selector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-13

--- a/openspec/changes/archive/2026-02-14-csv-group-selector/design.md
+++ b/openspec/changes/archive/2026-02-14-csv-group-selector/design.md
@@ -1,0 +1,73 @@
+## Context
+
+現在の CSV 登録フローでは、CsvTransformer が会議タイトルから groupId（SHA-256 先頭 8 桁）と groupName を自動生成し、それが mergeInput / sessionRecord にそのまま使用される。ユーザーがグループを選択する手段はなく、タイトルが空の場合は空文字列のハッシュで意図しないグループが作成される。
+
+関連するコンポーネント構成:
+- `AdminPage` → `FileQueueCardList` → `FileQueueCard`
+- `useFileQueue` フックが CsvTransformer を呼び出してパース結果を管理
+- パース結果の `mergeInput` / `sessionRecord` が `handleBulkSave` でそのまま保存に使用される
+
+## Goals / Non-Goals
+
+**Goals:**
+- FileQueueCard 内にグループ選択プルダウンを追加し、既存グループから選択可能にする
+- グループ名が空の CSV でもエラーにせず、プルダウンで既存グループを選択すれば保存可能にする
+- 選択されたグループの groupId / groupName で mergeInput と sessionRecord を上書きする
+
+**Non-Goals:**
+- 新規グループ名の自由入力（プルダウンからの既存グループ選択のみ）
+- CsvTransformer 自体の変更（パース結果の構造はそのまま維持）
+- sessionRecord / mergeInput のスキーマ変更
+
+## Decisions
+
+### 1. グループ上書き状態の管理場所: useFileQueue の reducer 内
+
+**選択**: useFileQueue の reducer に `SELECT_GROUP` アクションを追加し、キューアイテムに `groupOverride` フィールドを持たせる。
+
+**理由**: パース結果（`parseResult`）は CsvTransformer の出力として不変に保ち、ユーザー選択は別フィールドで管理する方がデバッグしやすく、元のパース結果を参照可能に保てる。
+
+**代替案**:
+- parseResult を直接書き換える → パース結果の不変性が崩れ、リセット操作が困難になるため不採用
+
+### 2. mergeInput / sessionRecord の上書きタイミング: 保存時
+
+**選択**: `handleBulkSave` 内で `groupOverride` がある場合に mergeInput と sessionRecord を上書きしてから保存する。
+
+**理由**: パース結果を不変に保ちつつ、保存直前に最終的なデータを構築する。FileQueueCard のサマリー表示には `groupOverride` がある場合はそちらの groupName を表示する。
+
+**代替案**:
+- useFileQueue 内のパース直後に上書き → グループ変更のたびにパース結果の再構築が必要になり複雑化するため不採用
+
+### 3. sessionId の再生成方法: groupId + 日付の連結
+
+**選択**: 保存時に `${newGroupId}-${date}` で sessionId を再生成する。CsvTransformer の `#generateId` は private メソッドなので、同じロジック（SHA-256 先頭 8 桁）を別のユーティリティとして切り出す必要はない。既存グループの groupId をそのまま使うため、ハッシュ再計算は不要。
+
+**理由**: 既存グループを選択した場合、そのグループの id（既にハッシュ生成済み）をそのまま使用するので、ハッシュ再計算は不要。
+
+### 4. グループ名が空の場合の扱い: `missing_group` ステータス
+
+**選択**: CsvTransformer のパース自体は成功（ok: true）のまま、useFileQueue 側で groupName が空の場合に `missing_group` ステータスを設定する。このステータスのアイテムは `readyItems` に含まれず、保存ボタンの対象外となる。プルダウンで既存グループを選択すると `ready` ステータスに遷移する。
+
+**理由**: CsvTransformer はあくまで CSV パーサーとしての責務に留め、グループ選択のバリデーションは UI 層で行う。
+
+**代替案**:
+- CsvTransformer でタイトル空をエラー（ok: false）にする → パース自体は正常に完了しており参加者データも取得できているため、error にすると情報が失われる。不採用
+
+### 5. プルダウンの配置と表示タイミング
+
+**選択**: FileQueueCard のパース結果サマリー行に配置。グループ名のテキスト表示をプルダウンに置き換える。パース成功後（hasParseResult が true）に常に表示する。
+
+**理由**: ユーザーが CSV をドロップした直後にグループを確認・変更できる自然な位置。
+
+### 6. グループ一覧の伝達経路
+
+**選択**: `AdminPage` → `FileQueueCardList` → `FileQueueCard` に `groups` prop をバケツリレーする。
+
+**理由**: 現在のコンポーネント階層は浅く（3 段）、Context や状態管理ライブラリの導入は過剰。props の追加で十分対応可能。
+
+## Risks / Trade-offs
+
+- **重複 sessionId のリスク**: グループを変更すると sessionId が変わるため、変更後の sessionId が既存と重複する可能性がある → `existingSessionIds` による重複チェックを `groupOverride` 適用後にも再実行して対処する
+- **保存中のグループ変更**: saving ステータスのアイテムはプルダウンを disabled にして変更を防止する
+- **グループ一覧の鮮度**: ページ読み込み時に取得したグループ一覧を使用するため、他ユーザーが同時にグループを追加した場合は反映されない → 既存の楽観的ロック機構（updatedAt 比較）で保護されているため、保存時に競合が検出される

--- a/openspec/changes/archive/2026-02-14-csv-group-selector/proposal.md
+++ b/openspec/changes/archive/2026-02-14-csv-group-selector/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+CSV登録時にグループ名がCSVの会議タイトルから自動抽出されるが、タイトルがない場合やCSVと異なるグループに登録したい場合に対応できない。ユーザーが既存グループをプルダウンから選択できるようにし、柔軟なグループ割り当てを実現する。
+
+## What Changes
+
+- FileQueueCard に既存グループを選択できるプルダウンUIを追加
+- CSV解析後、自動検出されたグループ名をデフォルト選択状態にする
+- グループ名が空（CSVにタイトルなし）の場合はエラー状態とし、プルダウンで既存グループを選択するまで保存不可にする
+- プルダウンで既存グループを選択した場合、そのグループの `groupId` と `groupName` で `mergeInput` を上書きする
+- sessionId も選択されたグループの groupId を基に再生成する（`groupId-YYYY-MM-DD` 形式）
+
+## Capabilities
+
+### New Capabilities
+
+- `csv-group-selector`: CSV登録時にFileQueueCard内で既存グループをプルダウンから選択する機能。グループ名が空の場合のエラーハンドリング、選択されたグループ情報による mergeInput / sessionId の上書きを含む
+
+### Modified Capabilities
+
+（既存 spec の要件レベルの変更なし）
+
+## Impact
+
+- **コンポーネント**: `FileQueueCard` — プルダウンUI追加、props 拡張（既存グループ一覧の受け渡し）
+- **フック**: `useFileQueue` — ユーザー選択グループの状態保持、mergeInput 上書きロジック追加
+- **ページ**: `AdminPage` — 既存グループ一覧を FileQueueCard に渡すデータフロー追加
+- **サービス**: `CsvTransformer` の出力構造は変更なし（mergeInput の上書きは useFileQueue 側で実施）
+- **データ**: `index.json` / `sessions/*.json` のスキーマ変更なし

--- a/openspec/changes/archive/2026-02-14-csv-group-selector/specs/csv-group-selector/spec.md
+++ b/openspec/changes/archive/2026-02-14-csv-group-selector/specs/csv-group-selector/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: グループ選択プルダウンの表示
+
+FileQueueCard は、CSVパース成功後にグループ選択プルダウンを表示しなければならない（SHALL）。プルダウンには AdminPage から取得した既存グループ一覧が選択肢として含まれなければならない（MUST）。各選択肢にはグループ名を表示する。
+
+#### Scenario: CSV パース成功後にプルダウンが表示される
+- **WHEN** CSV ファイルがドロップされパースが成功する
+- **THEN** FileQueueCard のサマリー行にグループ選択プルダウンが表示される
+
+#### Scenario: 既存グループが選択肢に表示される
+- **WHEN** プルダウンを開く
+- **THEN** AdminPage で取得済みの既存グループ一覧がすべて選択肢として表示される
+
+### Requirement: 自動検出グループのデフォルト選択
+
+CSV の会議タイトルから自動検出されたグループ名と一致する既存グループがある場合、そのグループがプルダウンのデフォルト値として選択されなければならない（MUST）。一致する既存グループがない場合は、自動検出されたグループ名を「新規グループ」として表示しなければならない（MUST）。
+
+#### Scenario: 自動検出グループが既存グループと一致する場合
+- **WHEN** CSV のタイトルから生成された groupId が既存グループの id と一致する
+- **THEN** プルダウンにはその既存グループがデフォルトで選択された状態になる
+
+#### Scenario: 自動検出グループが既存グループと一致しない場合
+- **WHEN** CSV のタイトルから生成された groupId がどの既存グループとも一致しない
+- **THEN** プルダウンには自動検出されたグループ名が「新規グループ」として表示・選択された状態になる
+
+### Requirement: グループ名が空の場合のエラー制御
+
+CSV の会議タイトルが空（グループ名が空文字列）の場合、アイテムは `missing_group` ステータスとなり保存不可にしなければならない（MUST）。プルダウンで既存グループを選択することで保存可能にしなければならない（MUST）。
+
+#### Scenario: グループ名が空のCSVがドロップされる
+- **WHEN** 会議タイトルが空の CSV ファイルがパースされる
+- **THEN** アイテムのステータスが `missing_group` になる
+- **THEN** 「グループを選択してください」というメッセージが表示される
+- **THEN** 一括保存ボタンの対象件数にこのアイテムは含まれない
+
+#### Scenario: グループ名が空のアイテムでグループを選択する
+- **WHEN** `missing_group` ステータスのアイテムでプルダウンから既存グループを選択する
+- **THEN** アイテムのステータスが `ready` に遷移する
+- **THEN** 一括保存ボタンの対象件数にこのアイテムが含まれるようになる
+
+### Requirement: 選択グループによる mergeInput の上書き
+
+プルダウンで既存グループを選択した場合、保存時に mergeInput の `groupId`・`groupName` と sessionRecord の `groupId` を選択されたグループの値で上書きしなければならない（MUST）。sessionId は `${選択グループのgroupId}-${日付}` で再生成しなければならない（MUST）。
+
+#### Scenario: 既存グループを選択して保存する
+- **WHEN** ユーザーがプルダウンで既存グループ（id: "abc12345", name: "勉強会A"）を選択する
+- **WHEN** 一括保存が実行される
+- **THEN** mergeInput の groupId が "abc12345" に上書きされる
+- **THEN** mergeInput の groupName が "勉強会A" に上書きされる
+- **THEN** sessionRecord の groupId が "abc12345" に上書きされる
+- **THEN** sessionId が "abc12345-{日付}" に再生成される
+- **THEN** sessionRecord の id も再生成された sessionId と一致する
+
+#### Scenario: 新規グループ（自動検出）のまま保存する
+- **WHEN** ユーザーがプルダウンを変更せず、自動検出グループのまま保存する
+- **THEN** mergeInput と sessionRecord は CsvTransformer の出力値がそのまま使用される
+
+### Requirement: グループ上書き後の重複チェック
+
+グループを変更すると sessionId が変わるため、変更後の sessionId に対して重複チェックを実施しなければならない（MUST）。
+
+#### Scenario: グループ変更後に sessionId が既存と重複する
+- **WHEN** プルダウンでグループを変更した結果、新しい sessionId が既存の sessionId と重複する
+- **THEN** アイテムのステータスが `duplicate_warning` に遷移する
+
+#### Scenario: グループ変更後に sessionId が既存と重複しない
+- **WHEN** プルダウンでグループを変更した結果、新しい sessionId が既存の sessionId と重複しない
+- **THEN** アイテムのステータスが `ready` のままとなる
+
+### Requirement: 保存中・保存済みアイテムのプルダウン無効化
+
+`saving` または `saved` ステータスのアイテムではプルダウンを無効化（disabled）しなければならない（MUST）。
+
+#### Scenario: 保存中のアイテムでプルダウンが操作不可になる
+- **WHEN** アイテムのステータスが `saving` である
+- **THEN** グループ選択プルダウンが disabled 状態になり操作できない
+
+#### Scenario: 保存済みのアイテムでプルダウンが操作不可になる
+- **WHEN** アイテムのステータスが `saved` である
+- **THEN** グループ選択プルダウンが disabled 状態になり操作できない

--- a/openspec/changes/archive/2026-02-14-csv-group-selector/tasks.md
+++ b/openspec/changes/archive/2026-02-14-csv-group-selector/tasks.md
@@ -1,0 +1,33 @@
+## 1. useFileQueue の拡張
+
+- [x] 1.1 fileQueueReducer に `SELECT_GROUP` アクションを追加し、キューアイテムに `groupOverride: { groupId, groupName }` フィールドを設定する
+- [x] 1.2 fileQueueReducer に `MISSING_GROUP` アクションを追加し、groupName が空のパース結果に対して `missing_group` ステータスを設定する
+- [x] 1.3 `parsePendingItem` 内で、パース成功かつ groupName が空の場合に `MISSING_GROUP` をディスパッチするロジックを追加する
+- [x] 1.4 `selectGroup` コールバック関数を追加し、`SELECT_GROUP` アクションをディスパッチする。`missing_group` ステータスの場合は `ready` に遷移させる
+- [x] 1.5 `SELECT_GROUP` 時に、変更後の sessionId（`${groupId}-${date}`）で `existingSessionIds` との重複チェックを行い、重複時は `duplicate_warning` ステータスに遷移させる
+- [x] 1.6 `readyItems` の useMemo フィルタに `missing_group` ステータスが含まれないことを確認する
+
+## 2. コンポーネントの更新
+
+- [x] 2.1 FileQueueCard に `groups` prop と `onSelectGroup` prop を追加する
+- [x] 2.2 FileQueueCard のサマリー行で、グループ名テキスト表示をプルダウン（`<select>`）に置き換える
+- [x] 2.3 プルダウンの選択肢に既存グループ一覧を表示し、`groupOverride` または自動検出グループをデフォルト選択にする
+- [x] 2.4 自動検出グループが既存グループと一致しない場合、「（新規）{グループ名}」の選択肢を先頭に追加する
+- [x] 2.5 `missing_group` ステータスの場合、「グループを選択してください」のプレースホルダーとエラーメッセージを表示する
+- [x] 2.6 `saving` / `saved` ステータスの場合、プルダウンを disabled にする
+- [x] 2.7 FileQueueCardList に `groups` prop と `onSelectGroup` prop を追加し、各 FileQueueCard にバケツリレーする
+
+## 3. AdminPage の更新
+
+- [x] 3.1 FileQueueCardList に `groups` state と `selectGroup` コールバックを渡す
+- [x] 3.2 `handleBulkSave` 内で、`groupOverride` が存在するアイテムに対して mergeInput の `groupId`・`groupName`・`sessionId` と sessionRecord の `groupId`・`id` を上書きするロジックを追加する
+
+## 4. テスト
+
+- [x] 4.1 useFileQueue のユニットテスト: `SELECT_GROUP` アクションによる `groupOverride` 設定を検証する
+- [x] 4.2 useFileQueue のユニットテスト: groupName 空の場合の `missing_group` ステータス遷移を検証する
+- [x] 4.3 useFileQueue のユニットテスト: グループ選択後の重複チェック（sessionId 再計算）を検証する
+- [x] 4.4 FileQueueCard のユニットテスト: プルダウン表示、デフォルト選択、既存グループ一覧の表示を検証する
+- [x] 4.5 FileQueueCard のユニットテスト: `missing_group` ステータス時のエラー表示とグループ選択後の遷移を検証する
+- [x] 4.6 AdminPage のユニットテスト: `handleBulkSave` での mergeInput 上書きロジックを検証する
+- [x] 4.7 既存テストが破壊されていないことを `pnpm test` で確認する

--- a/openspec/specs/csv-group-selector/spec.md
+++ b/openspec/specs/csv-group-selector/spec.md
@@ -1,0 +1,79 @@
+### Requirement: グループ選択プルダウンの表示
+
+FileQueueCard は、CSVパース成功後にグループ選択プルダウンを表示しなければならない（SHALL）。プルダウンには AdminPage から取得した既存グループ一覧が選択肢として含まれなければならない（MUST）。各選択肢にはグループ名を表示する。
+
+#### Scenario: CSV パース成功後にプルダウンが表示される
+- **WHEN** CSV ファイルがドロップされパースが成功する
+- **THEN** FileQueueCard のサマリー行にグループ選択プルダウンが表示される
+
+#### Scenario: 既存グループが選択肢に表示される
+- **WHEN** プルダウンを開く
+- **THEN** AdminPage で取得済みの既存グループ一覧がすべて選択肢として表示される
+
+### Requirement: 自動検出グループのデフォルト選択
+
+CSV の会議タイトルから自動検出されたグループ名と一致する既存グループがある場合、そのグループがプルダウンのデフォルト値として選択されなければならない（MUST）。一致する既存グループがない場合は、自動検出されたグループ名を「新規グループ」として表示しなければならない（MUST）。
+
+#### Scenario: 自動検出グループが既存グループと一致する場合
+- **WHEN** CSV のタイトルから生成された groupId が既存グループの id と一致する
+- **THEN** プルダウンにはその既存グループがデフォルトで選択された状態になる
+
+#### Scenario: 自動検出グループが既存グループと一致しない場合
+- **WHEN** CSV のタイトルから生成された groupId がどの既存グループとも一致しない
+- **THEN** プルダウンには自動検出されたグループ名が「新規グループ」として表示・選択された状態になる
+
+### Requirement: グループ名が空の場合のエラー制御
+
+CSV の会議タイトルが空（グループ名が空文字列）の場合、アイテムは `missing_group` ステータスとなり保存不可にしなければならない（MUST）。プルダウンで既存グループを選択することで保存可能にしなければならない（MUST）。
+
+#### Scenario: グループ名が空のCSVがドロップされる
+- **WHEN** 会議タイトルが空の CSV ファイルがパースされる
+- **THEN** アイテムのステータスが `missing_group` になる
+- **THEN** 「グループを選択してください」というメッセージが表示される
+- **THEN** 一括保存ボタンの対象件数にこのアイテムは含まれない
+
+#### Scenario: グループ名が空のアイテムでグループを選択する
+- **WHEN** `missing_group` ステータスのアイテムでプルダウンから既存グループを選択する
+- **THEN** アイテムのステータスが `ready` に遷移する
+- **THEN** 一括保存ボタンの対象件数にこのアイテムが含まれるようになる
+
+### Requirement: 選択グループによる mergeInput の上書き
+
+プルダウンで既存グループを選択した場合、保存時に mergeInput の `groupId`・`groupName` と sessionRecord の `groupId` を選択されたグループの値で上書きしなければならない（MUST）。sessionId は `${選択グループのgroupId}-${日付}` で再生成しなければならない（MUST）。
+
+#### Scenario: 既存グループを選択して保存する
+- **WHEN** ユーザーがプルダウンで既存グループ（id: "abc12345", name: "勉強会A"）を選択する
+- **WHEN** 一括保存が実行される
+- **THEN** mergeInput の groupId が "abc12345" に上書きされる
+- **THEN** mergeInput の groupName が "勉強会A" に上書きされる
+- **THEN** sessionRecord の groupId が "abc12345" に上書きされる
+- **THEN** sessionId が "abc12345-{日付}" に再生成される
+- **THEN** sessionRecord の id も再生成された sessionId と一致する
+
+#### Scenario: 新規グループ（自動検出）のまま保存する
+- **WHEN** ユーザーがプルダウンを変更せず、自動検出グループのまま保存する
+- **THEN** mergeInput と sessionRecord は CsvTransformer の出力値がそのまま使用される
+
+### Requirement: グループ上書き後の重複チェック
+
+グループを変更すると sessionId が変わるため、変更後の sessionId に対して重複チェックを実施しなければならない（MUST）。
+
+#### Scenario: グループ変更後に sessionId が既存と重複する
+- **WHEN** プルダウンでグループを変更した結果、新しい sessionId が既存の sessionId と重複する
+- **THEN** アイテムのステータスが `duplicate_warning` に遷移する
+
+#### Scenario: グループ変更後に sessionId が既存と重複しない
+- **WHEN** プルダウンでグループを変更した結果、新しい sessionId が既存の sessionId と重複しない
+- **THEN** アイテムのステータスが `ready` のままとなる
+
+### Requirement: 保存中・保存済みアイテムのプルダウン無効化
+
+`saving` または `saved` ステータスのアイテムではプルダウンを無効化（disabled）しなければならない（MUST）。
+
+#### Scenario: 保存中のアイテムでプルダウンが操作不可になる
+- **WHEN** アイテムのステータスが `saving` である
+- **THEN** グループ選択プルダウンが disabled 状態になり操作できない
+
+#### Scenario: 保存済みのアイテムでプルダウンが操作不可になる
+- **WHEN** アイテムのステータスが `saved` である
+- **THEN** グループ選択プルダウンが disabled 状態になり操作できない

--- a/src/components/FileQueueCardList.jsx
+++ b/src/components/FileQueueCardList.jsx
@@ -4,9 +4,9 @@ import { FileQueueCard } from './FileQueueCard.jsx';
  * ファイルキューカードリスト
  * queue を map して FileQueueCard を並べるリストラッパー
  *
- * @param {{ queue: Array, onRemove: (id: string) => void, onApproveDuplicate: (id: string) => void }} props
+ * @param {{ queue: Array, groups: Array, onRemove: (id: string) => void, onApproveDuplicate: (id: string) => void, onSelectGroup: (fileId: string, groupId: string, groupName: string) => void }} props
  */
-export function FileQueueCardList({ queue, onRemove, onApproveDuplicate }) {
+export function FileQueueCardList({ queue, groups = [], onRemove, onApproveDuplicate, onSelectGroup }) {
   if (queue.length === 0) return null;
 
   return (
@@ -15,8 +15,10 @@ export function FileQueueCardList({ queue, onRemove, onApproveDuplicate }) {
         <FileQueueCard
           key={item.id}
           item={item}
+          groups={groups}
           onRemove={onRemove}
           onApproveDuplicate={onApproveDuplicate}
+          onSelectGroup={onSelectGroup}
         />
       ))}
     </div>

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -55,6 +55,7 @@ export function AdminPage() {
     addFiles,
     removeFile,
     approveDuplicate,
+    selectGroup,
     setExistingSessionIds,
     updateStatus,
     readyItems,
@@ -97,7 +98,15 @@ export function AdminPage() {
       updateStatus(item.id, 'saving');
       setSaveStatusText(`保存中... ${item.file.name}`);
 
-      const { sessionRecord, mergeInput } = item.parseResult;
+      let { sessionRecord, mergeInput } = item.parseResult;
+
+      // グループ上書きがある場合、mergeInput / sessionRecord を上書き
+      if (item.groupOverride) {
+        const { groupId, groupName } = item.groupOverride;
+        const newSessionId = `${groupId}-${mergeInput.date}`;
+        mergeInput = { ...mergeInput, groupId, groupName, sessionId: newSessionId };
+        sessionRecord = { ...sessionRecord, groupId, id: newSessionId };
+      }
 
       const result = await blobWriter.executeWriteSequence({
         rawCsv: {
@@ -245,8 +254,10 @@ export function AdminPage() {
 
       <FileQueueCardList
         queue={queue}
+        groups={groups}
         onRemove={removeFile}
         onApproveDuplicate={approveDuplicate}
+        onSelectGroup={selectGroup}
       />
 
       {saving ? (

--- a/tests/react/components/FileQueueCard.test.jsx
+++ b/tests/react/components/FileQueueCard.test.jsx
@@ -1,0 +1,237 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FileQueueCard } from '../../../src/components/FileQueueCard.jsx';
+
+// 共通テストデータ
+const mockGroups = [
+    { id: 'grp001', name: 'フロントエンド勉強会', totalDurationSeconds: 7200, sessionIds: [] },
+    { id: 'grp002', name: 'バックエンド勉強会', totalDurationSeconds: 3600, sessionIds: [] },
+];
+
+function createReadyItem(overrides = {}) {
+    return {
+        id: 'item-1',
+        file: { name: 'test.csv', size: 1024 },
+        status: 'ready',
+        parseResult: {
+            ok: true,
+            mergeInput: {
+                sessionId: 'grp001-2026-01-15',
+                groupId: 'grp001',
+                groupName: 'フロントエンド勉強会',
+                date: '2026-01-15',
+                attendances: [
+                    { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+                ],
+            },
+        },
+        errors: [],
+        warnings: [],
+        hasDuplicate: false,
+        ...overrides,
+    };
+}
+
+describe('FileQueueCard — グループ選択プルダウン', () => {
+    it('パース成功後にグループ選択プルダウンが表示される', () => {
+        const item = createReadyItem();
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        const select = screen.getByRole('combobox');
+        expect(select).toBeInTheDocument();
+    });
+
+    it('既存グループが選択肢に表示される', () => {
+        const item = createReadyItem();
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        const options = screen.getAllByRole('option');
+        const optionTexts = options.map((o) => o.textContent);
+        expect(optionTexts).toContain('フロントエンド勉強会');
+        expect(optionTexts).toContain('バックエンド勉強会');
+    });
+
+    it('自動検出グループが既存と一致する場合デフォルト選択される', () => {
+        const item = createReadyItem();
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        const select = screen.getByRole('combobox');
+        expect(select.value).toBe('grp001');
+    });
+
+    it('自動検出グループが既存と一致しない場合「（新規）」オプションが表示される', () => {
+        const item = createReadyItem({
+            parseResult: {
+                ok: true,
+                mergeInput: {
+                    sessionId: 'newgrp1-2026-01-15',
+                    groupId: 'newgrp1',
+                    groupName: '新しい勉強会',
+                    date: '2026-01-15',
+                    attendances: [
+                        { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+                    ],
+                },
+            },
+        });
+
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        const options = screen.getAllByRole('option');
+        const newOption = options.find((o) => o.textContent.includes('（新規）'));
+        expect(newOption).toBeDefined();
+        expect(newOption.textContent).toBe('（新規）新しい勉強会');
+    });
+
+    it('プルダウンで別グループを選択すると onSelectGroup が呼ばれる', async () => {
+        const user = userEvent.setup();
+        const onSelectGroup = vi.fn();
+        const item = createReadyItem();
+
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={onSelectGroup}
+            />
+        );
+
+        const select = screen.getByRole('combobox');
+        await user.selectOptions(select, 'grp002');
+
+        expect(onSelectGroup).toHaveBeenCalledWith('item-1', 'grp002', 'バックエンド勉強会');
+    });
+});
+
+describe('FileQueueCard — missing_group ステータス', () => {
+    it('missing_group 時にエラーメッセージが表示される', () => {
+        const item = createReadyItem({
+            status: 'missing_group',
+            parseResult: {
+                ok: true,
+                mergeInput: {
+                    sessionId: 'e3b0c442-2026-01-15',
+                    groupId: 'e3b0c442',
+                    groupName: '',
+                    date: '2026-01-15',
+                    attendances: [
+                        { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+                    ],
+                },
+            },
+        });
+
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        expect(screen.getAllByText('グループを選択してください').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('missing_group 時にプルダウンの先頭が空のプレースホルダーになる', () => {
+        const item = createReadyItem({
+            status: 'missing_group',
+            parseResult: {
+                ok: true,
+                mergeInput: {
+                    sessionId: 'e3b0c442-2026-01-15',
+                    groupId: 'e3b0c442',
+                    groupName: '',
+                    date: '2026-01-15',
+                    attendances: [
+                        { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+                    ],
+                },
+            },
+        });
+
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        const select = screen.getByRole('combobox');
+        expect(select.value).toBe('');
+    });
+});
+
+describe('FileQueueCard — プルダウンの無効化', () => {
+    it('saving ステータスではプルダウンが disabled になる', () => {
+        const item = createReadyItem({ status: 'saving' });
+
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        const select = screen.getByRole('combobox');
+        expect(select).toBeDisabled();
+    });
+
+    it('saved ステータスではプルダウンが disabled になる', () => {
+        const item = createReadyItem({ status: 'saved' });
+
+        render(
+            <FileQueueCard
+                item={item}
+                groups={mockGroups}
+                onRemove={vi.fn()}
+                onApproveDuplicate={vi.fn()}
+                onSelectGroup={vi.fn()}
+            />
+        );
+
+        const select = screen.getByRole('combobox');
+        expect(select).toBeDisabled();
+    });
+});

--- a/tests/react/hooks/useFileQueue.test.jsx
+++ b/tests/react/hooks/useFileQueue.test.jsx
@@ -1,0 +1,160 @@
+import { renderHook, act } from '@testing-library/react';
+import { useFileQueue } from '../../../src/hooks/useFileQueue.js';
+
+// テスト用のモック CsvTransformer
+function createMockTransformer(parseResult) {
+    return { parse: vi.fn().mockResolvedValue(parseResult) };
+}
+
+// 標準的なパース成功結果
+function createParseResult(overrides = {}) {
+    return {
+        ok: true,
+        sessionRecord: {
+            id: 'abc12345-2026-01-15',
+            groupId: 'abc12345',
+            date: '2026-01-15',
+            attendances: [{ memberId: 'mem001', durationSeconds: 3600 }],
+        },
+        mergeInput: {
+            sessionId: 'abc12345-2026-01-15',
+            groupId: 'abc12345',
+            groupName: 'テスト勉強会',
+            date: '2026-01-15',
+            attendances: [
+                { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+            ],
+        },
+        warnings: [],
+        ...overrides,
+    };
+}
+
+// グループ名が空のパース結果
+function createEmptyGroupParseResult() {
+    return createParseResult({
+        sessionRecord: {
+            id: 'e3b0c442-2026-01-15',
+            groupId: 'e3b0c442',
+            date: '2026-01-15',
+            attendances: [{ memberId: 'mem001', durationSeconds: 3600 }],
+        },
+        mergeInput: {
+            sessionId: 'e3b0c442-2026-01-15',
+            groupId: 'e3b0c442',
+            groupName: '',
+            date: '2026-01-15',
+            attendances: [
+                { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+            ],
+        },
+    });
+}
+
+describe('useFileQueue — SELECT_GROUP', () => {
+    it('selectGroup で groupOverride が設定される', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        // ファイルを追加
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        // パース完了を待つ
+        await vi.waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        // グループ選択
+        act(() => {
+            result.current.selectGroup(itemId, 'newgroup1', '別のグループ');
+        });
+
+        expect(result.current.queue[0].groupOverride).toEqual({
+            groupId: 'newgroup1',
+            groupName: '別のグループ',
+        });
+        expect(result.current.queue[0].status).toBe('ready');
+    });
+
+    it('selectGroup で変更後の sessionId が既存と重複する場合 duplicate_warning になる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        // 既存セッションIDを設定（重複を発生させる）
+        act(() => {
+            result.current.setExistingSessionIds(new Set(['existgrp1-2026-01-15']));
+        });
+
+        // ファイルを追加
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await vi.waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        // 重複するグループを選択
+        act(() => {
+            result.current.selectGroup(itemId, 'existgrp1', '既存グループ');
+        });
+
+        expect(result.current.queue[0].status).toBe('duplicate_warning');
+        expect(result.current.queue[0].hasDuplicate).toBe(true);
+    });
+});
+
+describe('useFileQueue — MISSING_GROUP', () => {
+    it('groupName が空の場合 missing_group ステータスになる', async () => {
+        const transformer = createMockTransformer(createEmptyGroupParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await vi.waitFor(() => {
+            expect(result.current.queue[0].status).toBe('missing_group');
+        });
+
+        // readyItems に含まれないこと
+        expect(result.current.readyItems).toHaveLength(0);
+    });
+
+    it('missing_group のアイテムでグループを選択すると ready になる', async () => {
+        const transformer = createMockTransformer(createEmptyGroupParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await vi.waitFor(() => {
+            expect(result.current.queue[0].status).toBe('missing_group');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        // 既存グループを選択
+        act(() => {
+            result.current.selectGroup(itemId, 'existgrp1', '既存グループ');
+        });
+
+        expect(result.current.queue[0].status).toBe('ready');
+        expect(result.current.queue[0].groupOverride).toEqual({
+            groupId: 'existgrp1',
+            groupName: '既存グループ',
+        });
+        expect(result.current.readyItems).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary

- FileQueueCard にグループ選択プルダウンを追加し、CSV登録時に既存グループから選択可能にした
- グループ名が空（CSVにタイトルなし）の場合は `missing_group` ステータスで保存不可にし、プルダウンで既存グループを選択すれば保存可能にした
- 保存時に選択グループの groupId/groupName で mergeInput/sessionRecord を上書きし、sessionId も再生成するようにした

Closes #65

## Test plan

- [ ] `pnpm test` で全132テストが通ること
- [ ] 新規テスト（useFileQueue: 4件、FileQueueCard: 9件、AdminPage上書きロジック: 1件）が通ること
- [ ] 開発サーバーで CSV をドロップし、プルダウンに既存グループが表示されること
- [ ] プルダウンで既存グループを選択して一括保存し、正しい groupId/sessionId で保存されること
- [ ] グループ名が空の CSV をドロップした場合、「グループを選択してください」が表示され保存不可になること
- [ ] saving/saved 状態のアイテムでプルダウンが disabled になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)