### PR TITLE
fix: useFileQueue テストの act(...) 警告を修正

### DIFF
--- a/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-14

--- a/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/design.md
+++ b/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/design.md
@@ -1,0 +1,39 @@
+## Context
+
+`useFileQueue` フックは `addFiles` 呼び出し時に `useEffect` 経由で非同期パース処理を実行する。テストでは `act(() => addFiles([file]))` で同期的な dispatch をラップした後、`await vi.waitFor()` でパース完了を待機している。
+
+しかし `vi.waitFor`（Vitest 提供）はポーリング中のステート更新を React の `act()` でラップしない。一方、他のテストファイル（`AdminPage.test.jsx`、`DashboardPage.test.jsx` 等）はすべて `@testing-library/react` の `waitFor` を使用しており、act 警告は発生していない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 4つのテストケースで発生している `act(...)` 警告を解消する
+- プロジェクト全体のテストパターンを統一する（RTL の `waitFor` に統一）
+
+**Non-Goals:**
+
+- プロダクションコード（`useFileQueue.js`）の変更
+- テストケースの追加・削除やテストロジックの変更
+- 他のテストファイルのリファクタリング
+
+## Decisions
+
+### `vi.waitFor` → RTL `waitFor` への置き換え
+
+**選択**: `@testing-library/react` の `waitFor` を使用する
+
+**理由**:
+- RTL の `waitFor` はコールバック内のステート更新を自動的に `act()` でラップする
+- プロジェクト内の他のすべてのテストファイルが既にこのパターンを使用している
+- import 文の変更と `vi.waitFor` → `waitFor` の置き換えだけで完了する最小限の修正
+
+**却下した代替案**:
+
+1. **`await act(async () => { ... })` で全体をラップ** — `addFiles` から `waitFor` まですべてを1つの `act` で囲む方法。動作するが、`act` の中に長い非同期待機を入れるのは RTL のベストプラクティスに反する。
+2. **`vi.waitFor` のコールバック内で `act` を呼ぶ** — 冗長になり、RTL の `waitFor` が提供する機能と重複する。
+
+## Risks / Trade-offs
+
+- **[リスク] RTL `waitFor` と `vi.waitFor` の挙動差異** → RTL `waitFor` はデフォルトで 1000ms タイムアウト、50ms 間隔でポーリング。現在のテストは即座にパースが完了するモックなので実質的な差異はない。
+- **[リスク] import 変更による他テストへの影響** → `useFileQueue.test.jsx` のみの変更なので影響範囲は限定的。修正後にテストスイート全体を実行して確認する。

--- a/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/proposal.md
+++ b/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`useFileQueue.test.jsx` の4つのテストケースで React の `act(...)` 警告が stderr に出力されている。テスト自体はパスするが、CI ログにノイズが入り、将来的にテスト品質の劣化を見逃すリスクがある。`addFiles` 後に `useEffect` が非同期で `csvTransformer.parse()` を呼び出し、その完了時の `dispatch` が `act()` の外で発生していることが原因。
+
+## What Changes
+
+- `tests/react/hooks/useFileQueue.test.jsx` の非同期ステート更新を適切に `act()` でラップする
+- `addFiles` 呼び出し後のパース完了待機で `waitFor` を使用し、React のステート更新サイクルを正しく処理する
+- `selectGroup` 呼び出し後のアサーションについても `act()` ラップが必要か検証し、修正する
+
+## Capabilities
+
+### New Capabilities
+
+なし — テストコードの修正のみで、新たな機能やスペックの追加は不要。
+
+### Modified Capabilities
+
+なし — プロダクションコードの振る舞いに変更はない。テストの書き方の修正のみ。
+
+## Impact
+
+- **対象ファイル**: `tests/react/hooks/useFileQueue.test.jsx`（テストコードのみ）
+- **プロダクションコード**: 変更なし
+- **CI/CD**: テスト実行時の stderr 警告が解消される
+- **リスク**: 低（テストコードのみの修正、プロダクションコードは一切変更しない）

--- a/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/specs/test-act-warnings/spec.md
+++ b/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/specs/test-act-warnings/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: useFileQueue テストが act 警告なしで実行される
+`useFileQueue.test.jsx` のすべてのテストケースは、React の `act(...)` 警告を stderr に出力せずに実行を完了しなければならない（SHALL）。非同期ステート更新の待機には `@testing-library/react` の `waitFor` を使用しなければならない（SHALL）。
+
+#### Scenario: SELECT_GROUP テストケースが警告なしで通過する
+- **WHEN** `selectGroup で groupOverride が設定される` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+#### Scenario: SELECT_GROUP 重複テストケースが警告なしで通過する
+- **WHEN** `selectGroup で変更後の sessionId が既存と重複する場合 duplicate_warning になる` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+#### Scenario: MISSING_GROUP テストケースが警告なしで通過する
+- **WHEN** `groupName が空の場合 missing_group ステータスになる` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+#### Scenario: MISSING_GROUP からグループ選択テストケースが警告なしで通過する
+- **WHEN** `missing_group のアイテムでグループを選択すると ready になる` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+### Requirement: waitFor の使用パターンがプロジェクト規約に準拠する
+`useFileQueue.test.jsx` の非同期待機は `vi.waitFor` ではなく `@testing-library/react` の `waitFor` を使用しなければならない（SHALL）。これはプロジェクト内の他テストファイルと一貫したパターンである。
+
+#### Scenario: vi.waitFor が使用されていない
+- **WHEN** `useFileQueue.test.jsx` のソースコードを検査する
+- **THEN** `vi.waitFor` の呼び出しが存在しない
+
+#### Scenario: RTL waitFor が使用されている
+- **WHEN** `useFileQueue.test.jsx` のソースコードを検査する
+- **THEN** `@testing-library/react` から `waitFor` がインポートされ、非同期待機に使用されている

--- a/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/tasks.md
+++ b/openspec/changes/archive/2026-02-14-fix-usefilequeue-act-warnings/tasks.md
@@ -1,0 +1,17 @@
+## 1. import 文の修正
+
+- [x] 1.1 `useFileQueue.test.jsx` の import に `@testing-library/react` から `waitFor` を追加する
+- [x] 1.2 `renderHook, act` の既存 import に `waitFor` を追記する形式にする
+
+## 2. vi.waitFor → waitFor への置き換え
+
+- [x] 2.1 `selectGroup で groupOverride が設定される` テスト内の `vi.waitFor` を `waitFor` に置き換える（66行目付近）
+- [x] 2.2 `selectGroup で変更後の sessionId が既存と重複する場合` テスト内の `vi.waitFor` を `waitFor` に置き換える（99行目付近）
+- [x] 2.3 `groupName が空の場合 missing_group ステータスになる` テスト内の `vi.waitFor` を `waitFor` に置き換える（125行目付近）
+- [x] 2.4 `missing_group のアイテムでグループを選択すると ready になる` テスト内の `vi.waitFor` を `waitFor` に置き換える（142行目付近）
+
+## 3. テスト実行と検証
+
+- [x] 3.1 `pnpm vitest run tests/react/hooks/useFileQueue.test.jsx` で対象テストを実行し、全テストがパスすることを確認する
+- [x] 3.2 テスト実行時に stderr に `act(...)` 警告が出力されないことを確認する
+- [x] 3.3 `pnpm test` でテストスイート全体を実行し、既存テストに影響がないことを確認する

--- a/openspec/specs/test-act-warnings/spec.md
+++ b/openspec/specs/test-act-warnings/spec.md
@@ -1,0 +1,29 @@
+### Requirement: useFileQueue テストが act 警告なしで実行される
+`useFileQueue.test.jsx` のすべてのテストケースは、React の `act(...)` 警告を stderr に出力せずに実行を完了しなければならない（SHALL）。非同期ステート更新の待機には `@testing-library/react` の `waitFor` を使用しなければならない（SHALL）。
+
+#### Scenario: SELECT_GROUP テストケースが警告なしで通過する
+- **WHEN** `selectGroup で groupOverride が設定される` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+#### Scenario: SELECT_GROUP 重複テストケースが警告なしで通過する
+- **WHEN** `selectGroup で変更後の sessionId が既存と重複する場合 duplicate_warning になる` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+#### Scenario: MISSING_GROUP テストケースが警告なしで通過する
+- **WHEN** `groupName が空の場合 missing_group ステータスになる` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+#### Scenario: MISSING_GROUP からグループ選択テストケースが警告なしで通過する
+- **WHEN** `missing_group のアイテムでグループを選択すると ready になる` テストを実行する
+- **THEN** テストがパスし、stderr に `act(...)` 警告が出力されない
+
+### Requirement: waitFor の使用パターンがプロジェクト規約に準拠する
+`useFileQueue.test.jsx` の非同期待機は `vi.waitFor` ではなく `@testing-library/react` の `waitFor` を使用しなければならない（SHALL）。これはプロジェクト内の他テストファイルと一貫したパターンである。
+
+#### Scenario: vi.waitFor が使用されていない
+- **WHEN** `useFileQueue.test.jsx` のソースコードを検査する
+- **THEN** `vi.waitFor` の呼び出しが存在しない
+
+#### Scenario: RTL waitFor が使用されている
+- **WHEN** `useFileQueue.test.jsx` のソースコードを検査する
+- **THEN** `@testing-library/react` から `waitFor` がインポートされ、非同期待機に使用されている

--- a/tests/react/hooks/useFileQueue.test.jsx
+++ b/tests/react/hooks/useFileQueue.test.jsx
@@ -1,4 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useFileQueue } from '../../../src/hooks/useFileQueue.js';
 
 // テスト用のモック CsvTransformer
@@ -63,7 +63,7 @@ describe('useFileQueue — SELECT_GROUP', () => {
         });
 
         // パース完了を待つ
-        await vi.waitFor(() => {
+        await waitFor(() => {
             expect(result.current.queue[0].status).toBe('ready');
         });
 
@@ -96,7 +96,7 @@ describe('useFileQueue — SELECT_GROUP', () => {
             result.current.addFiles([file]);
         });
 
-        await vi.waitFor(() => {
+        await waitFor(() => {
             expect(result.current.queue[0].status).toBe('ready');
         });
 
@@ -122,7 +122,7 @@ describe('useFileQueue — MISSING_GROUP', () => {
             result.current.addFiles([file]);
         });
 
-        await vi.waitFor(() => {
+        await waitFor(() => {
             expect(result.current.queue[0].status).toBe('missing_group');
         });
 
@@ -139,7 +139,7 @@ describe('useFileQueue — MISSING_GROUP', () => {
             result.current.addFiles([file]);
         });
 
-        await vi.waitFor(() => {
+        await waitFor(() => {
             expect(result.current.queue[0].status).toBe('missing_group');
         });
 


### PR DESCRIPTION
## Summary
- `useFileQueue.test.jsx` の4つのテストケースで発生していた `act(...)` 警告を修正
- `vi.waitFor` → `@testing-library/react` の `waitFor` に置き換え、非同期ステート更新が `act()` 境界内で処理されるようにした
- プロジェクト内の他テストファイルと一貫したパターンに統一

## Test plan
- [x] `useFileQueue.test.jsx` の4テストがすべてパスすることを確認
- [x] テスト実行時に `act(...)` 警告が出力されないことを確認
- [x] テストスイート全体（19ファイル、132テスト）がすべてパスすることを確認

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)