### PR TITLE
refactor: DashboardPageの集計ロジック最適化とtoSorted()の採用

### DIFF
--- a/src/components/MemberList.jsx
+++ b/src/components/MemberList.jsx
@@ -14,7 +14,7 @@ export function MemberList({ members }) {
   }, [members, searchQuery]);
 
   const sortedMembers = useMemo(
-    () => [...filteredMembers].sort((a, b) => a.name.localeCompare(b.name, 'ja')),
+    () => filteredMembers.toSorted((a, b) => a.name.localeCompare(b.name, 'ja')),
     [filteredMembers]
   );
 

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -52,8 +52,13 @@ export function DashboardPage() {
 
   const { groups, members } = data;
 
-  const totalSessions = groups.reduce((acc, g) => acc + g.sessionIds.length, 0);
-  const totalDuration = groups.reduce((acc, g) => acc + g.totalDurationSeconds, 0);
+  const { totalSessions, totalDuration } = groups.reduce(
+    (acc, g) => ({
+      totalSessions: acc.totalSessions + g.sessionIds.length,
+      totalDuration: acc.totalDuration + g.totalDurationSeconds,
+    }),
+    { totalSessions: 0, totalDuration: 0 }
+  );
 
   return (
     <div className="space-y-8">


### PR DESCRIPTION
## 概要

DashboardPage の集計ロジックで2回実行されている \educe\ を1回に統合し、イミュータブルなソートを明示します。

## 変更内容

### DashboardPage.jsx
- totalSessions と totalDuration の2回の \educe\ を1回に統合
- 同時計算により不要な反復処理を削減

### MemberList.jsx
- \[...filteredMembers].sort()\ を \ilteredMembers.toSorted()\ に置換
- イミュータブルなソートを明示的に表現

## テスト実績

✅ pnpm test: 全146テスト合格  
✅ pnpm run lint: エラーなし  
✅ pnpm run build: ビルド成功  

## 関連する Issue

closes #76