### PR TITLE
Issue #75 CSV一括保存を並列化してウォーターフォールを解消

### DIFF
--- a/openspec/changes/parallelize-csv-bulk-save/.openspec.yaml
+++ b/openspec/changes/parallelize-csv-bulk-save/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-14

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -92,12 +92,9 @@ export function AdminPage() {
 
     setSaving(true);
     setSaveProgress({ current: 0, total: itemsToSave.length });
+    setSaveStatusText(`保存中... 0/${itemsToSave.length} 件`);
 
-    let completed = 0;
-    for (const item of itemsToSave) {
-      updateStatus(item.id, 'saving');
-      setSaveStatusText(`保存中... ${item.file.name}`);
-
+    const preparedItems = itemsToSave.map((item) => {
       let { sessionRecord, mergeInput } = item.parseResult;
 
       // グループ上書きがある場合、mergeInput / sessionRecord を上書き
@@ -108,34 +105,93 @@ export function AdminPage() {
         sessionRecord = { ...sessionRecord, groupId, id: newSessionId };
       }
 
-      const result = await blobWriter.executeWriteSequence({
-        rawCsv: {
-          path: `data/sources/${sessionRecord.id}.csv`,
-          content: item.file,
+      return {
+        itemId: item.id,
+        sourcePath: `data/sources/${sessionRecord.id}.csv`,
+        sessionPath: `data/sessions/${sessionRecord.id}.json`,
+        sourceFile: item.file,
+        sessionRecord,
+        mergeInput,
+      };
+    });
+
+    for (const prepared of preparedItems) {
+      updateStatus(prepared.itemId, 'saving');
+    }
+
+    const sessionPathSet = new Set(preparedItems.map((prepared) => prepared.sessionPath));
+    let completedSessions = 0;
+
+    const result = await blobWriter.executeWriteSequence({
+      newItems: preparedItems.flatMap((prepared) => [
+        {
+          path: prepared.sourcePath,
+          content: prepared.sourceFile,
           contentType: 'text/csv',
         },
-        newItems: [
-          {
-            path: `data/sessions/${sessionRecord.id}.json`,
-            content: JSON.stringify(sessionRecord, null, 2),
-            contentType: 'application/json',
-          },
-        ],
-        indexUpdater: (currentIndex) => indexMerger.merge(currentIndex, mergeInput).index,
-      });
+        {
+          path: prepared.sessionPath,
+          content: JSON.stringify(prepared.sessionRecord, null, 2),
+          contentType: 'application/json',
+        },
+      ]),
+      indexUpdater: (currentIndex, writeResults) => {
+        const resultByPath = new Map(writeResults.map((writeResult) => [writeResult.path, writeResult]));
+        const successfulMergeInputs = preparedItems
+          .filter(
+            (prepared) =>
+              (resultByPath.get(prepared.sourcePath)?.success ?? false) &&
+              (resultByPath.get(prepared.sessionPath)?.success ?? false)
+          )
+          .map((prepared) => prepared.mergeInput);
 
-      completed++;
-      setSaveProgress({ current: completed, total: itemsToSave.length });
+        if (successfulMergeInputs.length === 0) {
+          return null;
+        }
 
-      if (result.allSucceeded) {
-        updateStatus(item.id, 'saved');
+        return successfulMergeInputs.reduce(
+          (index, mergeInput) => indexMerger.merge(index, mergeInput).index,
+          currentIndex
+        );
+      },
+      onItemComplete: (writeResult) => {
+        if (!sessionPathSet.has(writeResult.path)) {
+          return;
+        }
+        completedSessions += 1;
+        setSaveProgress({ current: completedSessions, total: itemsToSave.length });
+        setSaveStatusText(`保存中... ${completedSessions}/${itemsToSave.length} 件`);
+      },
+    });
+
+    const resultByPath = new Map(result.results.map((writeResult) => [writeResult.path, writeResult]));
+    const indexWriteResult = resultByPath.get('data/index.json');
+
+    for (const prepared of preparedItems) {
+      const sourceWriteResult = resultByPath.get(prepared.sourcePath);
+      const sessionWriteResult = resultByPath.get(prepared.sessionPath);
+      const sourceSucceeded = sourceWriteResult?.success ?? result.allSucceeded;
+      const sessionSucceeded = sessionWriteResult?.success ?? result.allSucceeded;
+      const errors = [];
+
+      if (!sourceSucceeded) {
+        errors.push(sourceWriteResult?.error || 'CSVソース保存に失敗しました');
+      }
+      if (!sessionSucceeded) {
+        errors.push(sessionWriteResult?.error || 'セッションJSON保存に失敗しました');
+      }
+      if (errors.length === 0 && indexWriteResult && !indexWriteResult.success) {
+        errors.push(indexWriteResult.error || 'index.json の保存に失敗しました');
+      }
+
+      if (errors.length === 0) {
+        updateStatus(prepared.itemId, 'saved');
       } else {
-        updateStatus(item.id, 'save_failed', {
-          errors: result.results.filter((r) => !r.success).map((r) => r.error),
-        });
+        updateStatus(prepared.itemId, 'save_failed', { errors });
       }
     }
 
+    setSaveProgress({ current: itemsToSave.length, total: itemsToSave.length });
     setSaving(false);
     setSaveStatusText('');
   }, [queue, updateStatus, blobWriter, indexMerger]);

--- a/tests/react/pages/AdminPage.test.jsx
+++ b/tests/react/pages/AdminPage.test.jsx
@@ -87,7 +87,7 @@ describe('AdminPage — ソースファイル保存パス', () => {
     });
   });
 
-  it('一括保存時にrawCsv.pathが data/sources/{sessionId}.csv 形式であること', async () => {
+  it('一括保存時に data/sources/{sessionId}.csv が保存対象に含まれること', async () => {
     const user = userEvent.setup();
 
     render(
@@ -115,12 +115,16 @@ describe('AdminPage — ソースファイル保存パス', () => {
       expect(mockExecuteWriteSequence).toHaveBeenCalled();
     });
 
-    // rawCsv.path が data/sources/{sessionId}.csv 形式であることを検証
+    // data/sources/{sessionId}.csv 形式で保存対象に含まれることを検証
     const callArgs = mockExecuteWriteSequence.mock.calls[0][0];
-    expect(callArgs.rawCsv.path).toBe('data/sources/abc12345-2026-02-08.csv');
+    const sourceItem = callArgs.newItems.find((item) =>
+      item.path.startsWith('data/sources/abc12345-2026-02-08')
+    );
+    expect(sourceItem).toBeDefined();
+    expect(sourceItem.path).toBe('data/sources/abc12345-2026-02-08.csv');
 
     // raw/ ディレクトリへのパスでないことを検証
-    expect(callArgs.rawCsv.path).not.toMatch(/^raw\//);
+    expect(sourceItem.path).not.toMatch(/^raw\//);
   });
 });
 
@@ -207,12 +211,16 @@ describe('AdminPage — グループ選択による mergeInput 上書き', () =>
 
     // 上書きされたパスを検証
     const callArgs = mockExecuteWriteSequence.mock.calls[0][0];
+    const sourceItem = callArgs.newItems.find((item) => item.path.startsWith('data/sources/'));
+    const sessionItem = callArgs.newItems.find((item) => item.path.startsWith('data/sessions/'));
+    expect(sourceItem).toBeDefined();
+    expect(sessionItem).toBeDefined();
     // groupOverride により sessionId が existgrp1-2026-02-08 に変更される
-    expect(callArgs.rawCsv.path).toBe('data/sources/existgrp1-2026-02-08.csv');
-    expect(callArgs.newItems[0].path).toBe('data/sessions/existgrp1-2026-02-08.json');
+    expect(sourceItem.path).toBe('data/sources/existgrp1-2026-02-08.csv');
+    expect(sessionItem.path).toBe('data/sessions/existgrp1-2026-02-08.json');
 
     // sessionRecord の中身も上書きされていることを確認
-    const sessionRecord = JSON.parse(callArgs.newItems[0].content);
+    const sessionRecord = JSON.parse(sessionItem.content);
     expect(sessionRecord.id).toBe('existgrp1-2026-02-08');
     expect(sessionRecord.groupId).toBe('existgrp1');
   });


### PR DESCRIPTION
## 概要
CSV一括保存時の逐次PUTによるウォーターフォールを解消するため、セッションデータ保存を並列化し、index.json更新を1回に集約しました。

## 変更内容
- BlobWriter.executeWriteSequence の 
ewItems 書き込みを Promise.all で並列化
- BlobWriter に onItemComplete コールバックと indexUpdater(currentIndex, writeResults) を追加
- AdminPage の一括保存を「全アイテム並列保存→成功分マージ→index.json単一更新」に変更
- 保存進捗表示を「完了件数/総件数」の並列処理向け表示に変更
- BlobWriter/AdminPage関連テストを更新・追加
- OpenSpec change スキャフォールドを追加（parallelize-csv-bulk-save）

## テスト
- 
pm run test
- 
pm run lint
- 
pm run build
- 
pm run test:e2e

Closes #75