### PR TITLE
AdminPage を React.lazy で遅延読み込みする

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,33 @@
+import { lazy, Suspense } from 'react';
 import { createHashRouter, RouterProvider, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './hooks/useAuth.jsx';
 import { DashboardPage } from './pages/DashboardPage.jsx';
 import { MemberDetailPage } from './pages/MemberDetailPage.jsx';
 import { GroupDetailPage } from './pages/GroupDetailPage.jsx';
-import { AdminPage } from './pages/AdminPage.jsx';
 import { BookOpen, Settings } from 'lucide-react';
+
+const loadAdminPage = () => import('./pages/AdminPage.jsx');
+const LazyAdminPage = lazy(loadAdminPage);
+
+const adminLoadingFallback = (
+  <div className="rounded-lg border border-border-light bg-surface px-4 py-3 text-sm text-text-muted">
+    管理画面を読み込み中...
+  </div>
+);
 
 // ルート定義
 const router = createHashRouter([
   { path: '/', element: <DashboardPage /> },
   { path: '/members/:memberId', element: <MemberDetailPage /> },
   { path: '/groups/:groupId', element: <GroupDetailPage /> },
-  { path: '/admin', element: <AdminPage /> },
+  {
+    path: '/admin',
+    element: (
+      <Suspense fallback={adminLoadingFallback}>
+        <LazyAdminPage />
+      </Suspense>
+    ),
+  },
   { path: '*', element: <Navigate to="/" replace /> },
 ]);
 
@@ -43,6 +59,8 @@ function AppLayout() {
           {isAdmin && (
             <a
               href="#/admin"
+              onMouseEnter={loadAdminPage}
+              onFocus={loadAdminPage}
               className="inline-flex items-center gap-1.5 text-sm text-text-secondary hover:text-primary-600 transition-colors"
             >
               <Settings className="w-4 h-4" />

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -367,3 +367,5 @@ export function AdminPage() {
     </div>
   );
 }
+
+export default AdminPage;


### PR DESCRIPTION
## 概要

Issue #71 の対応として、管理画面を遅延読み込みに変更し、管理リンクのホバー時プリロードを追加しました。

## 変更内容

- `src/App.jsx`
  - `AdminPage` を `React.lazy()` で動的インポートに変更
  - `/admin` ルートを `Suspense` でラップし、ローディング表示を追加
  - ヘッダーの「管理」リンクに `onMouseEnter` / `onFocus` でプリロードを追加
- `src/pages/AdminPage.jsx`
  - `React.lazy` で扱えるよう `default export` を追加

## 検証

- `pnpm run lint` ✅
- `pnpm test` ✅
- `pnpm run build` ✅
  - `dist/assets/AdminPage-*.js` の分離を確認
- `pnpm run test:e2e` ❌（既存の実行不安定性により timeout/abort が発生）

## 関連 Issue

- Closes #71
- E2E の waitUntil/タイムアウト方針は #84 に切り分け
