### PR TITLE
Web Interface Guidelinesに基づくアクセシビリティ改善

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -109,3 +109,16 @@
     @apply rounded-lg;
   }
 }
+
+/* アニメーション軽減設定への対応 */
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in,
+  .animate-fade-in-up,
+  .animate-scale-in {
+    animation: none !important;
+  }
+
+  .skeleton {
+    animation: none !important;
+  }
+}

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
-import { useNavigate, Navigate } from 'react-router-dom';
+import { Navigate, Link } from 'react-router-dom';
 import { useAuth, createAuthAdapter } from '../hooks/useAuth.jsx';
 import { useFileQueue } from '../hooks/useFileQueue.js';
 import { FileDropZone } from '../components/FileDropZone.jsx';
@@ -21,7 +21,6 @@ import { GroupNameEditor } from '../components/GroupNameEditor.jsx';
  */
 export function AdminPage() {
   const auth = useAuth();
-  const navigate = useNavigate();
   const authAdapter = useMemo(() => createAuthAdapter(auth), [auth]);
 
   const csvTransformer = useMemo(() => new CsvTransformer(), []);
@@ -92,7 +91,7 @@ export function AdminPage() {
 
     setSaving(true);
     setSaveProgress({ current: 0, total: itemsToSave.length });
-    setSaveStatusText(`保存中... 0/${itemsToSave.length} 件`);
+    setSaveStatusText(`保存中\u2026 0/${itemsToSave.length} 件`);
 
     const preparedItems = itemsToSave.map((item) => {
       let { sessionRecord, mergeInput } = item.parseResult;
@@ -160,7 +159,7 @@ export function AdminPage() {
         }
         completedSessions += 1;
         setSaveProgress({ current: completedSessions, total: itemsToSave.length });
-        setSaveStatusText(`保存中... ${completedSessions}/${itemsToSave.length} 件`);
+        setSaveStatusText(`保存中\u2026 ${completedSessions}/${itemsToSave.length} 件`);
       },
     });
 
@@ -293,13 +292,13 @@ export function AdminPage() {
   return (
     <div className="space-y-6">
       {/* 戻るボタン */}
-      <button
-        onClick={() => navigate('/')}
-        className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded-lg px-3 py-1.5 -ml-3 transition-colors"
+      <Link
+        to="/"
+        className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded-lg px-3 py-1.5 -ml-3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
       >
-        <ArrowLeft className="w-4 h-4" />
+        <ArrowLeft className="w-4 h-4" aria-hidden="true" />
         ダッシュボードへ戻る
-      </button>
+      </Link>
 
       <div>
         <h2 className="text-xl font-bold text-text-primary tracking-tight">管理者パネル</h2>
@@ -327,20 +326,20 @@ export function AdminPage() {
         <div className="flex items-center gap-3">
           {readyItems.length > 0 && (
             <button
-              className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-xl shadow-sm hover:bg-primary-700 transition-colors text-sm font-medium"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-primary-600 text-white rounded-xl shadow-sm hover:bg-primary-700 transition-colors text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
               onClick={handleBulkSave}
             >
-              <Upload className="w-4 h-4" />
+              <Upload className="w-4 h-4" aria-hidden="true" />
               一括保存 ({readyItems.length}件)
             </button>
           )}
 
           {failedItems.length > 0 && (
             <button
-              className="inline-flex items-center gap-2 px-4 py-2 bg-accent-100 text-accent-600 border border-accent-300 rounded-xl hover:bg-accent-200 transition-colors text-sm font-medium"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-accent-100 text-accent-600 border border-accent-300 rounded-xl hover:bg-accent-200 transition-colors text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent-500 focus-visible:ring-offset-2"
               onClick={handleRetry}
             >
-              <RotateCcw className="w-4 h-4" />
+              <RotateCcw className="w-4 h-4" aria-hidden="true" />
               失敗した操作をリトライ ({failedItems.length}件)
             </button>
           )}
@@ -356,22 +355,24 @@ export function AdminPage() {
           </p>
         </div>
 
-        {groupMessage.text && (
-          <div
-            className={`mb-4 p-3 rounded-xl flex items-center gap-2 animate-scale-in ${
-              groupMessage.type === 'success'
-                ? 'bg-green-50 text-green-800'
-                : 'bg-red-50 text-red-800'
-            }`}
-          >
-            {groupMessage.type === 'success' ? (
-              <CheckCircle className="w-5 h-5" />
-            ) : (
-              <AlertCircle className="w-5 h-5" />
-            )}
-            <span className="text-sm">{groupMessage.text}</span>
-          </div>
-        )}
+        <div aria-live="polite">
+          {groupMessage.text && (
+            <div
+              className={`mb-4 p-3 rounded-xl flex items-center gap-2 animate-scale-in ${
+                groupMessage.type === 'success'
+                  ? 'bg-green-50 text-green-800'
+                  : 'bg-red-50 text-red-800'
+              }`}
+            >
+              {groupMessage.type === 'success' ? (
+                <CheckCircle className="w-5 h-5" aria-hidden="true" />
+              ) : (
+                <AlertCircle className="w-5 h-5" aria-hidden="true" />
+              )}
+              <span className="text-sm">{groupMessage.text}</span>
+            </div>
+          )}
+        </div>
 
         {groups.length === 0 ? (
           <p className="text-sm text-text-muted">グループがありません</p>

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -65,7 +65,7 @@ export function DashboardPage() {
             </div>
           </div>
         </div>
-        <span className="sr-only">読み込み中...</span>
+        <span className="sr-only">読み込み中…</span>
       </div>
     );
   }

--- a/src/pages/GroupDetailPage.jsx
+++ b/src/pages/GroupDetailPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { DataFetcher } from '../services/data-fetcher.js';
 import { formatDuration } from '../utils/format-duration.js';
 import {
@@ -18,7 +18,6 @@ const fetcher = new DataFetcher();
  */
 export function GroupDetailPage() {
   const { groupId } = useParams();
-  const navigate = useNavigate();
   const [group, setGroup] = useState(null);
   const [sessionDetails, setSessionDetails] = useState([]);
   const [expandedSessions, setExpandedSessions] = useState(new Set());
@@ -131,7 +130,7 @@ export function GroupDetailPage() {
             <div className="h-4 w-36 skeleton" />
           </div>
         ))}
-        <span className="sr-only">読み込み中...</span>
+        <span className="sr-only">読み込み中…</span>
       </div>
     );
   }
@@ -142,13 +141,13 @@ export function GroupDetailPage() {
         <div className="mx-auto max-w-xl mt-8 card-base border-l-4 border-l-error p-4 text-red-700">
           {error}
         </div>
-        <button
-          onClick={() => navigate('/')}
-          className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 transition-colors"
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-lg"
         >
-          <ArrowLeft className="w-4 h-4" />
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" />
           一覧へ戻る
-        </button>
+        </Link>
       </div>
     );
   }
@@ -156,28 +155,28 @@ export function GroupDetailPage() {
   return (
     <div className="space-y-6">
       {/* 戻るボタン */}
-      <button
-        onClick={() => navigate('/')}
-        className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded-lg px-3 py-1.5 -ml-3 transition-colors"
+      <Link
+        to="/"
+        className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded-lg px-3 py-1.5 -ml-3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
       >
-        <ArrowLeft className="w-4 h-4" />
+        <ArrowLeft className="w-4 h-4" aria-hidden="true" />
         一覧へ戻る
-      </button>
+      </Link>
 
       {/* グループヘッダーカード */}
       <div className="card-base p-8 flex items-center gap-6 animate-fade-in-up">
         <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-primary-100 to-primary-200 flex items-center justify-center text-primary-700">
-          <Users className="w-8 h-8" />
+          <Users className="w-8 h-8" aria-hidden="true" />
         </div>
         <div>
           <h2 className="text-xl font-bold text-text-primary">{group.name}</h2>
           <div className="flex items-center gap-4 mt-2 text-sm text-text-secondary">
             <span className="flex items-center gap-1.5">
-              <Calendar className="w-4 h-4 text-text-muted" />
+              <Calendar className="w-4 h-4 text-text-muted" aria-hidden="true" />
               {group.sessionIds.length}回開催
             </span>
             <span className="flex items-center gap-1.5">
-              <Clock className="w-4 h-4 text-text-muted" />
+              <Clock className="w-4 h-4 text-text-muted" aria-hidden="true" />
               合計 {formatDuration(group.totalDurationSeconds)}
             </span>
           </div>
@@ -197,23 +196,24 @@ export function GroupDetailPage() {
               {/* セッションサマリーカード */}
               <button
                 onClick={() => toggleSession(session.sessionId)}
-                className="w-full p-6 flex items-center justify-between text-left hover:bg-surface-muted transition-colors"
+                aria-expanded={isExpanded}
+                className="w-full p-6 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
               >
                 <div className="flex items-center gap-4">
                   {isExpanded ? (
-                    <ChevronDown className="w-5 h-5 text-text-muted" />
+                    <ChevronDown className="w-5 h-5 text-text-muted" aria-hidden="true" />
                   ) : (
-                    <ChevronRight className="w-5 h-5 text-text-muted" />
+                    <ChevronRight className="w-5 h-5 text-text-muted" aria-hidden="true" />
                   )}
                   <div>
                     <h3 className="text-base font-bold text-text-primary">{session.date}</h3>
                     <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
                       <span className="flex items-center gap-1.5">
-                        <Users className="w-3.5 h-3.5 text-text-muted" />
+                        <Users className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
                         {session.attendeeCount}名参加
                       </span>
                       <span className="flex items-center gap-1.5">
-                        <Clock className="w-3.5 h-3.5 text-text-muted" />
+                        <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
                         {formatDuration(session.totalDurationSeconds)}
                       </span>
                     </div>

--- a/src/pages/MemberDetailPage.jsx
+++ b/src/pages/MemberDetailPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { DataFetcher } from '../services/data-fetcher.js';
 import { formatDuration } from '../utils/format-duration.js';
 import { ArrowLeft, Clock, Calendar, ChevronDown, ChevronRight } from 'lucide-react';
@@ -11,7 +11,6 @@ const fetcher = new DataFetcher();
  */
 export function MemberDetailPage() {
   const { memberId } = useParams();
-  const navigate = useNavigate();
   const [member, setMember] = useState(null);
   const [groupAttendances, setGroupAttendances] = useState([]);
   const [expandedGroups, setExpandedGroups] = useState(new Set());
@@ -129,7 +128,7 @@ export function MemberDetailPage() {
             <div className="h-4 w-36 skeleton" />
           </div>
         ))}
-        <span className="sr-only">読み込み中...</span>
+        <span className="sr-only">読み込み中…</span>
       </div>
     );
   }
@@ -140,13 +139,13 @@ export function MemberDetailPage() {
         <div className="mx-auto max-w-xl mt-8 card-base border-l-4 border-l-error p-4 text-red-700">
           {error}
         </div>
-        <button
-          onClick={() => navigate('/')}
-          className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 transition-colors"
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 rounded-lg"
         >
-          <ArrowLeft className="w-4 h-4" />
+          <ArrowLeft className="w-4 h-4" aria-hidden="true" />
           一覧へ戻る
-        </button>
+        </Link>
       </div>
     );
   }
@@ -154,13 +153,13 @@ export function MemberDetailPage() {
   return (
     <div className="space-y-6">
       {/* 戻るボタン */}
-      <button
-        onClick={() => navigate('/')}
-        className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded-lg px-3 py-1.5 -ml-3 transition-colors"
+      <Link
+        to="/"
+        className="inline-flex items-center gap-2 text-sm text-primary-600 hover:text-primary-800 hover:bg-primary-50 rounded-lg px-3 py-1.5 -ml-3 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
       >
-        <ArrowLeft className="w-4 h-4" />
+        <ArrowLeft className="w-4 h-4" aria-hidden="true" />
         一覧へ戻る
-      </button>
+      </Link>
 
       {/* メンバーヘッダーカード */}
       <div className="card-base p-8 flex items-center gap-6 animate-fade-in-up">
@@ -171,11 +170,11 @@ export function MemberDetailPage() {
           <h2 className="text-xl font-bold text-text-primary">{member.name}</h2>
           <div className="flex items-center gap-4 mt-2 text-sm text-text-secondary">
             <span className="flex items-center gap-1.5">
-              <Clock className="w-4 h-4 text-text-muted" />
+              <Clock className="w-4 h-4 text-text-muted" aria-hidden="true" />
               合計 {formatDuration(member.totalDurationSeconds)}
             </span>
             <span className="flex items-center gap-1.5">
-              <Calendar className="w-4 h-4 text-text-muted" />
+              <Calendar className="w-4 h-4 text-text-muted" aria-hidden="true" />
               {member.sessionIds.length}回参加
             </span>
           </div>
@@ -195,23 +194,24 @@ export function MemberDetailPage() {
               {/* サマリーカード */}
               <button
                 onClick={() => toggleGroup(group.groupId)}
-                className="w-full p-6 flex items-center justify-between text-left hover:bg-surface-muted transition-colors"
+                aria-expanded={isExpanded}
+                className="w-full p-6 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
               >
                 <div className="flex items-center gap-4">
                   {isExpanded ? (
-                    <ChevronDown className="w-5 h-5 text-text-muted" />
+                    <ChevronDown className="w-5 h-5 text-text-muted" aria-hidden="true" />
                   ) : (
-                    <ChevronRight className="w-5 h-5 text-text-muted" />
+                    <ChevronRight className="w-5 h-5 text-text-muted" aria-hidden="true" />
                   )}
                   <div>
                     <h3 className="text-base font-bold text-text-primary">{group.groupName}</h3>
                     <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
                       <span className="flex items-center gap-1.5">
-                        <Calendar className="w-3.5 h-3.5 text-text-muted" />
+                        <Calendar className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
                         {group.sessionCount}回参加
                       </span>
                       <span className="flex items-center gap-1.5">
-                        <Clock className="w-3.5 h-3.5 text-text-muted" />
+                        <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
                         {formatDuration(group.totalDurationSeconds)}
                       </span>
                     </div>

--- a/tests/react/pages/DashboardPage.test.jsx
+++ b/tests/react/pages/DashboardPage.test.jsx
@@ -29,7 +29,7 @@ describe('DashboardPage', () => {
     vi.clearAllMocks();
   });
 
-  it('ローディング中に「読み込み中...」と表示すること', () => {
+  it('ローディング中に「読み込み中…」と表示すること', () => {
     mockFetchIndex.mockReturnValue(new Promise(() => {}));
 
     render(
@@ -38,7 +38,7 @@ describe('DashboardPage', () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.getByText('読み込み中…')).toBeInTheDocument();
   });
 
   it('データ取得成功時にグループ・メンバー一覧を表示すること', async () => {

--- a/tests/react/pages/GroupDetailPage.test.jsx
+++ b/tests/react/pages/GroupDetailPage.test.jsx
@@ -86,11 +86,11 @@ describe('GroupDetailPage', () => {
     vi.clearAllMocks();
   });
 
-  it('ローディング中に「読み込み中...」と表示すること', () => {
+  it('ローディング中に「読み込み中…」と表示すること', () => {
     mockFetchIndex.mockReturnValue(new Promise(() => {}));
 
     renderWithRouter('g1');
-    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.getByText('読み込み中…')).toBeInTheDocument();
   });
 
   it('グループ情報とセッション一覧を表示すること', async () => {

--- a/tests/react/pages/MemberDetailPage.test.jsx
+++ b/tests/react/pages/MemberDetailPage.test.jsx
@@ -52,11 +52,11 @@ describe('MemberDetailPage', () => {
     vi.clearAllMocks();
   });
 
-  it('ローディング中に「読み込み中...」と表示すること', () => {
+  it('ローディング中に「読み込み中…」と表示すること', () => {
     mockFetchIndex.mockReturnValue(new Promise(() => {}));
 
     renderWithRouter('m1');
-    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.getByText('読み込み中…')).toBeInTheDocument();
   });
 
   it('メンバー情報とセッション出席履歴を表示すること', async () => {


### PR DESCRIPTION
## Summary
- Web Interface Guidelinesレビュー結果に基づき、`src/pages/`配下の4ページコンポーネントのアクセシビリティを改善
- `prefers-reduced-motion`対応、セマンティックなナビゲーション（`<Link>`化）、ARIA属性の適切な付与、キーボード操作のフォーカス表示を追加
- 省略記号を正しいUnicode文字（`…` U+2026）に統一

## 変更内容

### Critical
- **prefers-reduced-motion対応** — `animate-fade-in-up`, `animate-scale-in`, `skeleton`に`@media (prefers-reduced-motion: reduce)`でアニメーション無効化（`src/index.css`）
- **ナビゲーションボタンをLink化** — `<button onClick={navigate}>` → `<Link to="/">`に変更し、Cmd+クリック・右クリックメニューに対応（AdminPage, GroupDetailPage, MemberDetailPage: 6箇所）

### Warning
- **装飾アイコンに`aria-hidden="true"`追加** — lucide-reactアイコンがスクリーンリーダーに読まれないよう対応（全4ファイル）
- **`focus-visible`スタイル追加** — ボタン・リンクにキーボードフォーカス時のリング表示（AdminPage, GroupDetailPage, MemberDetailPage）
- **アコーディオンに`aria-expanded`追加** — 展開/折りたたみ状態をスクリーンリーダーに伝達（GroupDetailPage, MemberDetailPage）
- **`aria-live="polite"`追加** — グループ名保存の成功/エラー通知をスクリーンリーダーに読み上げ（AdminPage）

### Info
- **省略記号の統一** — `...` → `…`（U+2026）に修正（全4ページ + テスト3ファイル）

### 付随修正
- 未使用の`useNavigate` importと変数を3ファイルから削除

## Test plan
- [x] `pnpm run lint` — ESLint通過確認済み
- [x] `pnpm test` — 151テスト全通過確認済み（テスト側の省略記号も修正）
- [ ] ブラウザで各ページを目視確認
- [ ] キーボードナビゲーションでfocus ringが表示されることを確認
- [ ] OSの「アニメーションを減らす」設定でアニメーション無効化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)