### PR TITLE
Reorder dashboard summary cards for better UX

### DIFF
--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -92,9 +92,9 @@ export function DashboardPage() {
     <div className="space-y-10">
       {/* 統計カード */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <SummaryCard title="総参加時間" value={formatDuration(totalDuration)} icon={Clock} style={{ animationDelay: '0ms' }} />
-        <SummaryCard title="総開催回数" value={`${totalSessions}回`} icon={Users} style={{ animationDelay: '100ms' }} />
-        <SummaryCard title="参加人数" value={`${members.length}人`} icon={User} style={{ animationDelay: '200ms' }} />
+        <SummaryCard title="総開催回数" value={`${totalSessions}回`} icon={Users} style={{ animationDelay: '0ms' }} />
+        <SummaryCard title="参加人数" value={`${members.length}人`} icon={User} style={{ animationDelay: '100ms' }} />
+        <SummaryCard title="総参加時間" value={formatDuration(totalDuration)} icon={Clock} style={{ animationDelay: '200ms' }} />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 items-start">


### PR DESCRIPTION
## Summary
Reordered the summary cards on the dashboard to present information in a more logical sequence that prioritizes key metrics.

## Changes
- Moved "総開催回数" (Total Sessions) card to the first position
- Moved "参加人数" (Total Members) card to the second position
- Moved "総参加時間" (Total Duration) card to the third position
- Updated animation delays accordingly to maintain staggered animation effect

## Details
The cards are now ordered by logical importance: total sessions held, number of participants, and total participation time. The animation delays have been adjusted to maintain the same visual stagger effect (0ms, 100ms, 200ms) with the new card order.

https://claude.ai/code/session_01GqWRMjd33NTxfzVX6J1vfM