### PR TITLE
Add fiscal period grouping to GroupDetailPage with 2-column layout

### DIFF
--- a/src/pages/GroupDetailPage.jsx
+++ b/src/pages/GroupDetailPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { DataFetcher } from '../services/data-fetcher.js';
 import { formatDuration } from '../utils/format-duration.js';
+import { getFiscalPeriod } from '../utils/fiscal-period.js';
 import {
   ArrowLeft,
   Clock,
@@ -14,12 +15,13 @@ import {
 const fetcher = new DataFetcher();
 
 /**
- * グループ詳細画面 — セッション一覧と参加者詳細を表示
+ * グループ詳細画面 — 期別2カラムレイアウトでセッション一覧と参加者詳細を表示
  */
 export function GroupDetailPage() {
   const { groupId } = useParams();
   const [group, setGroup] = useState(null);
-  const [sessionDetails, setSessionDetails] = useState([]);
+  const [periodSessions, setPeriodSessions] = useState([]);
+  const [selectedPeriodLabel, setSelectedPeriodLabel] = useState(null);
   const [expandedSessions, setExpandedSessions] = useState(new Set());
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -59,8 +61,8 @@ export function GroupDetailPage() {
         return;
       }
 
-      // セッションごとに参加者情報を構築
-      const details = [];
+      // 期別にセッションをグルーピング
+      const periodMap = new Map();
       for (const result of sessionResults) {
         if (!result.ok) continue;
         const session = result.data;
@@ -75,7 +77,23 @@ export function GroupDetailPage() {
         }));
         // 参加者を名前の日本語ロケール順でソート
         attendees.sort((a, b) => a.name.localeCompare(b.name, 'ja'));
-        details.push({
+
+        const period = getFiscalPeriod(session.date);
+        if (!periodMap.has(period.label)) {
+          periodMap.set(period.label, {
+            label: period.label,
+            fiscalYear: period.fiscalYear,
+            half: period.half,
+            sortKey: period.sortKey,
+            totalSessions: 0,
+            totalDurationSeconds: 0,
+            sessions: [],
+          });
+        }
+        const periodEntry = periodMap.get(period.label);
+        periodEntry.totalSessions += 1;
+        periodEntry.totalDurationSeconds += totalDurationSeconds;
+        periodEntry.sessions.push({
           sessionId: session.id,
           date: session.date,
           attendeeCount: attendees.length,
@@ -84,14 +102,25 @@ export function GroupDetailPage() {
         });
       }
 
-      // セッションを日付降順でソート
-      details.sort((a, b) => b.date.localeCompare(a.date));
+      // 各期内でセッションを日付降順でソート
+      const periods = Array.from(periodMap.values());
+      for (const period of periods) {
+        period.sessions.sort((a, b) => b.date.localeCompare(a.date));
+      }
 
-      setSessionDetails(details);
+      // 期を降順ソート（最新が先頭）
+      periods.sort((a, b) => b.sortKey - a.sortKey);
 
-      // セッションが1件のみの場合はデフォルトで展開
-      if (details.length === 1) {
-        setExpandedSessions(new Set([details[0].sessionId]));
+      setPeriodSessions(periods);
+
+      // デフォルトで最新の期を選択
+      if (periods.length > 0) {
+        setSelectedPeriodLabel(periods[0].label);
+      }
+
+      // 選択した期のセッションが1件のみの場合はデフォルトで展開
+      if (periods.length > 0 && periods[0].sessions.length === 1) {
+        setExpandedSessions(new Set([periods[0].sessions[0].sessionId]));
       }
 
       setLoading(false);
@@ -112,6 +141,8 @@ export function GroupDetailPage() {
       return next;
     });
   };
+
+  const selectedPeriod = periodSessions.find((p) => p.label === selectedPeriodLabel);
 
   if (loading) {
     return (
@@ -186,78 +217,112 @@ export function GroupDetailPage() {
         </div>
       </div>
 
-      {/* セッション別サマリー＋アコーディオン */}
-      <div className="space-y-4">
-        {sessionDetails.map((session, index) => {
-          const isExpanded = expandedSessions.has(session.sessionId);
-          return (
-            <div
-              key={session.sessionId}
-              className="card-base overflow-hidden animate-fade-in-up"
-              style={{ animationDelay: `${index * 80}ms` }}
-            >
-              {/* セッションサマリーカード */}
+      {/* 期別2カラムレイアウト */}
+      <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-6">
+        {/* 左列: 期サマリーリスト */}
+        <div className="space-y-2">
+          {periodSessions.map((period) => {
+            const isSelected = period.label === selectedPeriodLabel;
+            return (
               <button
-                onClick={() => toggleSession(session.sessionId)}
-                aria-expanded={isExpanded}
-                className="w-full p-6 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                key={period.label}
+                onClick={() => setSelectedPeriodLabel(period.label)}
+                aria-pressed={isSelected}
+                className={`w-full text-left px-4 py-3 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
+                  isSelected
+                    ? 'bg-primary-50 border-l-4 border-l-primary-500'
+                    : 'hover:bg-surface-muted border-l-4 border-l-transparent'
+                }`}
               >
-                <div className="flex items-center gap-4">
-                  {isExpanded ? (
-                    <ChevronDown className="w-5 h-5 text-text-muted" aria-hidden="true" />
-                  ) : (
-                    <ChevronRight className="w-5 h-5 text-text-muted" aria-hidden="true" />
-                  )}
-                  <div>
-                    <h3 className="text-base font-bold text-text-primary">{session.date}</h3>
-                    <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
-                      <span className="flex items-center gap-1.5">
-                        <Users className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
-                        <span className="font-display font-semibold text-text-primary">{session.attendeeCount}</span>名参加
-                      </span>
-                      <span className="flex items-center gap-1.5">
-                        <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
-                        <span className="font-display">{formatDuration(session.totalDurationSeconds)}</span>
-                      </span>
-                    </div>
-                  </div>
+                <div className="text-sm font-bold text-text-primary">{period.label}</div>
+                <div className="flex items-center gap-3 mt-1 text-xs text-text-secondary">
+                  <span className="flex items-center gap-1">
+                    <Calendar className="w-3 h-3 text-text-muted" aria-hidden="true" />
+                    <span className="font-display font-semibold">{period.totalSessions}</span>回
+                  </span>
+                  <span className="flex items-center gap-1">
+                    <Clock className="w-3 h-3 text-text-muted" aria-hidden="true" />
+                    <span className="font-display">{formatDuration(period.totalDurationSeconds)}</span>
+                  </span>
                 </div>
               </button>
+            );
+          })}
+        </div>
 
-              {/* 参加者テーブル（スムーズアコーディオン展開） */}
+        {/* 右列: 選択した期のセッション別アコーディオン */}
+        <div className="space-y-4">
+          {selectedPeriod && selectedPeriod.sessions.map((session, index) => {
+            const isExpanded = expandedSessions.has(session.sessionId);
+            return (
               <div
-                className="accordion-panel"
-                data-expanded={isExpanded}
-                aria-hidden={!isExpanded}
+                key={session.sessionId}
+                className="card-base overflow-hidden animate-fade-in-up"
+                style={{ animationDelay: `${index * 80}ms` }}
               >
-                <div className="accordion-panel-inner">
-                  <div className="border-t border-border-light">
-                    <div className="overflow-x-auto">
-                      <table className="w-full">
-                        <thead>
-                          <tr className="border-b border-border-light bg-surface-muted text-left text-xs text-text-muted uppercase tracking-wider">
-                            <th className="px-6 py-3 font-medium">名前</th>
-                            <th className="px-6 py-3 font-medium text-right">参加時間</th>
-                          </tr>
-                        </thead>
-                        <tbody className="divide-y divide-border-light">
-                          {session.attendees.map((attendee) => (
-                            <tr key={attendee.memberId} className="text-sm hover:bg-surface-muted transition-colors">
-                              <td className="px-6 py-3 text-text-primary">{attendee.name}</td>
-                              <td className="px-6 py-3 text-text-primary text-right font-medium font-display tabular-nums">
-                                {formatDuration(attendee.durationSeconds)}
-                              </td>
+                {/* セッションサマリーカード */}
+                <button
+                  onClick={() => toggleSession(session.sessionId)}
+                  aria-expanded={isExpanded}
+                  className="w-full p-6 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                >
+                  <div className="flex items-center gap-4">
+                    {isExpanded ? (
+                      <ChevronDown className="w-5 h-5 text-text-muted" aria-hidden="true" />
+                    ) : (
+                      <ChevronRight className="w-5 h-5 text-text-muted" aria-hidden="true" />
+                    )}
+                    <div>
+                      <h3 className="text-base font-bold text-text-primary">{session.date}</h3>
+                      <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
+                        <span className="flex items-center gap-1.5">
+                          <Users className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
+                          <span className="font-display font-semibold text-text-primary">{session.attendeeCount}</span>名参加
+                        </span>
+                        <span className="flex items-center gap-1.5">
+                          <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
+                          <span className="font-display">{formatDuration(session.totalDurationSeconds)}</span>
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </button>
+
+                {/* 参加者テーブル（スムーズアコーディオン展開） */}
+                <div
+                  className="accordion-panel"
+                  data-expanded={isExpanded}
+                  aria-hidden={!isExpanded}
+                >
+                  <div className="accordion-panel-inner">
+                    <div className="border-t border-border-light">
+                      <div className="overflow-x-auto">
+                        <table className="w-full">
+                          <thead>
+                            <tr className="border-b border-border-light bg-surface-muted text-left text-xs text-text-muted uppercase tracking-wider">
+                              <th className="px-6 py-3 font-medium">名前</th>
+                              <th className="px-6 py-3 font-medium text-right">参加時間</th>
                             </tr>
-                          ))}
-                        </tbody>
-                      </table>
+                          </thead>
+                          <tbody className="divide-y divide-border-light">
+                            {session.attendees.map((attendee) => (
+                              <tr key={attendee.memberId} className="text-sm hover:bg-surface-muted transition-colors">
+                                <td className="px-6 py-3 text-text-primary">{attendee.name}</td>
+                                <td className="px-6 py-3 text-text-primary text-right font-medium font-display tabular-nums">
+                                  {formatDuration(attendee.durationSeconds)}
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/tests/react/pages/GroupDetailPage.test.jsx
+++ b/tests/react/pages/GroupDetailPage.test.jsx
@@ -1,4 +1,5 @@
-import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { GroupDetailPage } from '../../../src/pages/GroupDetailPage.jsx';
 
@@ -71,6 +72,60 @@ const mockSessionDataSingle = {
   attendances: [{ memberId: 'm1', durationSeconds: 3600 }],
 };
 
+// 複数期にまたがるモックデータ
+const mockMultiPeriodIndexData = {
+  groups: [
+    {
+      id: 'g1',
+      name: 'フロントエンド勉強会',
+      totalDurationSeconds: 9000,
+      sessionIds: ['g1-2025-06-15', 'g1-2025-08-20', 'g1-2026-01-15'],
+    },
+  ],
+  members: [
+    {
+      id: 'm1',
+      name: '佐藤 一郎',
+      totalDurationSeconds: 5400,
+      sessionIds: ['g1-2025-06-15', 'g1-2025-08-20', 'g1-2026-01-15'],
+    },
+    {
+      id: 'm2',
+      name: '高橋 美咲',
+      totalDurationSeconds: 3600,
+      sessionIds: ['g1-2025-06-15', 'g1-2026-01-15'],
+    },
+  ],
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const mockMultiPeriodSessions = {
+  'g1-2025-06-15': {
+    id: 'g1-2025-06-15',
+    groupId: 'g1',
+    date: '2025-06-15',
+    attendances: [
+      { memberId: 'm1', durationSeconds: 1800 },
+      { memberId: 'm2', durationSeconds: 1200 },
+    ],
+  },
+  'g1-2025-08-20': {
+    id: 'g1-2025-08-20',
+    groupId: 'g1',
+    date: '2025-08-20',
+    attendances: [{ memberId: 'm1', durationSeconds: 3600 }],
+  },
+  'g1-2026-01-15': {
+    id: 'g1-2026-01-15',
+    groupId: 'g1',
+    date: '2026-01-15',
+    attendances: [
+      { memberId: 'm1', durationSeconds: 1800 },
+      { memberId: 'm2', durationSeconds: 2400 },
+    ],
+  },
+};
+
 function renderWithRouter(groupId) {
   return render(
     <MemoryRouter initialEntries={[`/groups/${groupId}`]}>
@@ -111,6 +166,9 @@ describe('GroupDetailPage', () => {
     const headerCard = screen.getByText('フロントエンド勉強会').closest('div');
     expect(headerCard.textContent).toContain('2回開催');
 
+    // 期サマリーが表示される（2025年度 下期 = 2026年1月）
+    expect(screen.getByText('2025年度 下期')).toBeInTheDocument();
+
     // セッション日付が表示される（日付降順）
     const headings = screen.getAllByRole('heading', { level: 3 });
     const dates = headings.map((h) => h.textContent);
@@ -119,6 +177,7 @@ describe('GroupDetailPage', () => {
   });
 
   it('セッションをクリックして参加者テーブルを展開・折りたたみできること', async () => {
+    const user = userEvent.setup();
     mockFetchIndex.mockResolvedValue({ ok: true, data: mockIndexData });
     mockFetchSession.mockImplementation((sid) => {
       if (sid === 'g1-2026-01-15') return Promise.resolve({ ok: true, data: mockSessionData1 });
@@ -136,14 +195,14 @@ describe('GroupDetailPage', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
 
     // セッションをクリックして展開
-    fireEvent.click(screen.getByText('2026-01-15'));
+    await user.click(screen.getByText('2026-01-15'));
     const table = screen.getByRole('table');
     expect(table).toBeInTheDocument();
     expect(within(table).getByText('佐藤 一郎')).toBeInTheDocument();
     expect(within(table).getByText('高橋 美咲')).toBeInTheDocument();
 
     // 再クリックで折りたたみ
-    fireEvent.click(screen.getByText('2026-01-15'));
+    await user.click(screen.getByText('2026-01-15'));
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 
@@ -194,6 +253,97 @@ describe('GroupDetailPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('一覧へ戻る')).toBeInTheDocument();
+    });
+  });
+
+  describe('期別表示', () => {
+    it('複数期のサマリーが降順で表示されること', async () => {
+      mockFetchIndex.mockResolvedValue({ ok: true, data: mockMultiPeriodIndexData });
+      mockFetchSession.mockImplementation((id) =>
+        Promise.resolve({ ok: true, data: mockMultiPeriodSessions[id] })
+      );
+
+      renderWithRouter('g1');
+
+      await waitFor(() => {
+        expect(screen.getByText('フロントエンド勉強会')).toBeInTheDocument();
+      });
+
+      // 期サマリーが降順で表示される
+      const periodButtons = screen.getAllByRole('button', { pressed: undefined });
+      const periodLabels = periodButtons
+        .filter((btn) => btn.getAttribute('aria-pressed') !== null)
+        .map((btn) => btn.textContent);
+      expect(periodLabels[0]).toContain('2025年度 下期');
+      expect(periodLabels[1]).toContain('2025年度 上期');
+    });
+
+    it('最新の期がデフォルトで選択されること', async () => {
+      mockFetchIndex.mockResolvedValue({ ok: true, data: mockMultiPeriodIndexData });
+      mockFetchSession.mockImplementation((id) =>
+        Promise.resolve({ ok: true, data: mockMultiPeriodSessions[id] })
+      );
+
+      renderWithRouter('g1');
+
+      await waitFor(() => {
+        expect(screen.getByText('フロントエンド勉強会')).toBeInTheDocument();
+      });
+
+      // 最新の期（2025年度 下期）が選択されている
+      const selectedButton = screen.getByRole('button', { pressed: true });
+      expect(selectedButton).toHaveTextContent('2025年度 下期');
+
+      // 下期のセッション（2026-01-15）が右列に表示される
+      expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('2026-01-15');
+    });
+
+    it('期を切り替えるとその期のセッションが表示されること', async () => {
+      const user = userEvent.setup();
+      mockFetchIndex.mockResolvedValue({ ok: true, data: mockMultiPeriodIndexData });
+      mockFetchSession.mockImplementation((id) =>
+        Promise.resolve({ ok: true, data: mockMultiPeriodSessions[id] })
+      );
+
+      renderWithRouter('g1');
+
+      await waitFor(() => {
+        expect(screen.getByText('フロントエンド勉強会')).toBeInTheDocument();
+      });
+
+      // 上期ボタンをクリック
+      const firstHalfButton = screen.getByRole('button', { pressed: false });
+      await user.click(firstHalfButton);
+
+      // 上期のボタンが選択状態になる
+      expect(firstHalfButton).toHaveAttribute('aria-pressed', 'true');
+
+      // 上期のセッション日付が表示される（2025-08-20, 2025-06-15 の2件）
+      const headings = screen.getAllByRole('heading', { level: 3 });
+      const dates = headings.map((h) => h.textContent);
+      expect(dates).toContain('2025-08-20');
+      expect(dates).toContain('2025-06-15');
+    });
+
+    it('期サマリーにセッション数と合計時間が表示されること', async () => {
+      mockFetchIndex.mockResolvedValue({ ok: true, data: mockMultiPeriodIndexData });
+      mockFetchSession.mockImplementation((id) =>
+        Promise.resolve({ ok: true, data: mockMultiPeriodSessions[id] })
+      );
+
+      renderWithRouter('g1');
+
+      await waitFor(() => {
+        expect(screen.getByText('フロントエンド勉強会')).toBeInTheDocument();
+      });
+
+      // 下期（1セッション）の期ボタン
+      const selectedButton = screen.getByRole('button', { pressed: true });
+      expect(selectedButton.textContent).toContain('1回');
+
+      // 上期（2セッション）の期ボタン
+      const unselectedButton = screen.getByRole('button', { pressed: false });
+      expect(unselectedButton.textContent).toContain('2回');
     });
   });
 });


### PR DESCRIPTION
## Summary
Refactored the GroupDetailPage to organize sessions by fiscal period instead of displaying them in a flat list. The new layout uses a 2-column design with period summaries on the left and session details on the right, improving navigation for groups with sessions spanning multiple fiscal periods.

## Key Changes
- **Fiscal period grouping**: Sessions are now grouped by fiscal period (e.g., "2025年度 上期", "2025年度 下期") using the new `getFiscalPeriod` utility function
- **2-column layout**: Implemented a responsive grid layout with:
  - Left column: Period summary buttons showing session count and total duration
  - Right column: Accordion-style session details for the selected period
- **Period selection**: Added state management for the selected period, with the latest period selected by default
- **Sorting**: Periods are sorted in descending order (newest first), and sessions within each period are sorted by date in descending order
- **Period aggregation**: Each period displays aggregated metrics (total sessions and total duration) calculated from its contained sessions

## Implementation Details
- Added `periodSessions` state to store hierarchical period/session data structure
- Added `selectedPeriodLabel` state to track the currently selected period
- Refactored data fetching logic to build a `periodMap` that groups sessions by fiscal period
- Updated UI to render period buttons with selection state and session accordions conditionally based on selection
- Enhanced test suite with comprehensive multi-period test cases covering period display, selection, and switching behavior
- Replaced `fireEvent` with `userEvent` in tests for more realistic user interaction simulation

https://claude.ai/code/session_01VRhBZmepNxRPAqzUaG9qeF

Closed: #108 