### PR TITLE
Add comprehensive test coverage for useFileQueue and useAuth hooks

### DIFF
--- a/tests/react/hooks/useFileQueue.test.jsx
+++ b/tests/react/hooks/useFileQueue.test.jsx
@@ -51,6 +51,496 @@ function createEmptyGroupParseResult() {
     });
 }
 
+describe('useFileQueue — ファイルバリデーション', () => {
+    it('CSV以外のファイルはエラーになる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.txt', { type: 'text/plain' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('error');
+        });
+
+        expect(result.current.queue[0].errors).toContain('CSVファイルのみ対応しています');
+        // パーサーは呼ばれないこと
+        expect(transformer.parse).not.toHaveBeenCalled();
+    });
+
+    it('10MBを超えるファイルはエラーになる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        // 10MB超のファイルを作成
+        const largeContent = new ArrayBuffer(10 * 1024 * 1024 + 1);
+        const file = new File([largeContent], 'large.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('error');
+        });
+
+        expect(result.current.queue[0].errors).toContain('ファイルサイズが10MBを超えています');
+        expect(transformer.parse).not.toHaveBeenCalled();
+    });
+});
+
+describe('useFileQueue — パース処理', () => {
+    it('パース失敗時にエラーステータスになる', async () => {
+        const transformer = createMockTransformer({
+            ok: false,
+            errors: ['CSVフォーマットが不正です'],
+        });
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('error');
+        });
+
+        expect(result.current.queue[0].errors).toContain('CSVフォーマットが不正です');
+    });
+
+    it('パース成功時にreadyステータスになりreadyItemsに含まれる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        expect(result.current.queue[0].parseResult).toBeTruthy();
+        expect(result.current.readyItems).toHaveLength(1);
+    });
+
+    it('警告付きのパース結果が正しく保持される', async () => {
+        const transformer = createMockTransformer(
+            createParseResult({ warnings: ['参加者名が不明です'] })
+        );
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        expect(result.current.queue[0].warnings).toEqual(['参加者名が不明です']);
+    });
+
+    it('既存セッションIDと重複する場合はduplicate_warningになる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        // 既存セッションIDを設定
+        act(() => {
+            result.current.setExistingSessionIds(new Set(['abc12345-2026-01-15']));
+        });
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('duplicate_warning');
+        });
+
+        expect(result.current.queue[0].hasDuplicate).toBe(true);
+        expect(result.current.queue[0].parseResult).toBeTruthy();
+    });
+});
+
+describe('useFileQueue — 重複承認', () => {
+    it('approveDuplicate でduplicate_warningからreadyに変更される', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        // 既存セッションIDを設定して重複を発生させる
+        act(() => {
+            result.current.setExistingSessionIds(new Set(['abc12345-2026-01-15']));
+        });
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('duplicate_warning');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        // 重複を承認
+        act(() => {
+            result.current.approveDuplicate(itemId);
+        });
+
+        expect(result.current.queue[0].status).toBe('ready');
+        expect(result.current.readyItems).toHaveLength(1);
+    });
+});
+
+describe('useFileQueue — ファイル削除', () => {
+    it('removeFile でキューからアイテムが削除される', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        act(() => {
+            result.current.removeFile(itemId);
+        });
+
+        expect(result.current.queue).toHaveLength(0);
+    });
+});
+
+describe('useFileQueue — 保存ステータス更新', () => {
+    it('updateStatus("saving") でsavingステータスになる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        act(() => {
+            result.current.updateStatus(itemId, 'saving');
+        });
+
+        expect(result.current.queue[0].status).toBe('saving');
+    });
+
+    it('updateStatus("saved") でsavedステータスになる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        act(() => {
+            result.current.updateStatus(itemId, 'saved');
+        });
+
+        expect(result.current.queue[0].status).toBe('saved');
+    });
+
+    it('updateStatus("save_failed") でsave_failedステータスになりfailedItemsに含まれる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        act(() => {
+            result.current.updateStatus(itemId, 'save_failed', {
+                errors: ['ネットワークエラー'],
+            });
+        });
+
+        expect(result.current.queue[0].status).toBe('save_failed');
+        expect(result.current.queue[0].errors).toEqual(['ネットワークエラー']);
+        expect(result.current.failedItems).toHaveLength(1);
+    });
+
+    it('updateStatus("save_failed") でextra未指定時は空配列になる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        act(() => {
+            result.current.updateStatus(itemId, 'save_failed');
+        });
+
+        expect(result.current.queue[0].status).toBe('save_failed');
+        expect(result.current.queue[0].errors).toEqual([]);
+    });
+
+    it('updateStatus("ready") でreadyステータスにリセットされる', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        // save_failedにしてからreadyにリセット
+        act(() => {
+            result.current.updateStatus(itemId, 'save_failed', {
+                errors: ['エラー'],
+            });
+        });
+
+        expect(result.current.queue[0].status).toBe('save_failed');
+
+        act(() => {
+            result.current.updateStatus(itemId, 'ready');
+        });
+
+        expect(result.current.queue[0].status).toBe('ready');
+        expect(result.current.queue[0].errors).toEqual([]);
+    });
+
+    it('updateStatus で未知のステータスを渡しても状態が変わらない', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        act(() => {
+            result.current.updateStatus(itemId, 'unknown_status');
+        });
+
+        // ステータスは変わらない
+        expect(result.current.queue[0].status).toBe('ready');
+    });
+});
+
+describe('useFileQueue — 複数アイテム操作', () => {
+    it('複数アイテムがある場合、対象アイテムのみステータスが変更される', async () => {
+        let callCount = 0;
+        const transformer = {
+            parse: vi.fn().mockImplementation(() => {
+                callCount++;
+                return Promise.resolve(
+                    createParseResult({
+                        sessionRecord: {
+                            id: `group${callCount}-2026-01-15`,
+                            groupId: `group${callCount}`,
+                            date: '2026-01-15',
+                            attendances: [{ memberId: 'mem001', durationSeconds: 3600 }],
+                        },
+                        mergeInput: {
+                            sessionId: `group${callCount}-2026-01-15`,
+                            groupId: `group${callCount}`,
+                            groupName: `グループ${callCount}`,
+                            date: '2026-01-15',
+                            attendances: [
+                                {
+                                    memberId: 'mem001',
+                                    memberName: '佐藤 太郎',
+                                    durationSeconds: 3600,
+                                },
+                            ],
+                        },
+                    })
+                );
+            }),
+        };
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        // 2つのファイルを追加
+        const file1 = new File(['dummy1'], 'test1.csv', { type: 'text/csv' });
+        const file2 = new File(['dummy2'], 'test2.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file1, file2]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue).toHaveLength(2);
+            expect(result.current.queue.every((item) => item.status === 'ready')).toBe(true);
+        });
+
+        const firstItemId = result.current.queue[0].id;
+
+        // 1つ目のアイテムだけsavingにする
+        act(() => {
+            result.current.updateStatus(firstItemId, 'saving');
+        });
+
+        expect(result.current.queue[0].status).toBe('saving');
+        expect(result.current.queue[1].status).toBe('ready');
+
+        // 1つ目をsavedにする
+        act(() => {
+            result.current.updateStatus(firstItemId, 'saved');
+        });
+
+        expect(result.current.queue[0].status).toBe('saved');
+        expect(result.current.queue[1].status).toBe('ready');
+    });
+
+    it('approveDuplicate はduplicate_warningステータス以外のアイテムには影響しない', async () => {
+        const transformer = createMockTransformer(createParseResult());
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        // readyステータスのアイテムにapproveDuplicateしても変化しない
+        act(() => {
+            result.current.approveDuplicate(itemId);
+        });
+
+        expect(result.current.queue[0].status).toBe('ready');
+    });
+});
+
+describe('useFileQueue — SELECT_GROUP 分岐', () => {
+    it('parseResult の date が null の場合、重複チェックがスキップされる', async () => {
+        const resultWithNoDate = createParseResult({
+            mergeInput: {
+                sessionId: 'abc12345-2026-01-15',
+                groupId: 'abc12345',
+                groupName: 'テスト勉強会',
+                date: null,
+                attendances: [
+                    { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+                ],
+            },
+        });
+        const transformer = createMockTransformer(resultWithNoDate);
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        // 既存セッションIDを設定
+        act(() => {
+            result.current.setExistingSessionIds(new Set(['existgrp1-2026-01-15']));
+        });
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('ready');
+        });
+
+        const itemId = result.current.queue[0].id;
+
+        // グループ選択（dateがnullなので重複チェックがスキップされる）
+        act(() => {
+            result.current.selectGroup(itemId, 'existgrp1', '既存グループ');
+        });
+
+        // dateがnullなのでnewSessionIdもnull → 重複にならずready
+        expect(result.current.queue[0].status).toBe('ready');
+        expect(result.current.queue[0].hasDuplicate).toBeFalsy();
+    });
+
+    it('警告がundefinedのパース結果でもwarningsが空配列になる', async () => {
+        // warnings プロパティが undefined の結果
+        const resultWithoutWarnings = {
+            ok: true,
+            sessionRecord: {
+                id: 'abc12345-2026-01-15',
+                groupId: 'abc12345',
+                date: '2026-01-15',
+                attendances: [{ memberId: 'mem001', durationSeconds: 3600 }],
+            },
+            mergeInput: {
+                sessionId: 'abc12345-2026-01-15',
+                groupId: 'abc12345',
+                groupName: '',
+                date: '2026-01-15',
+                attendances: [
+                    { memberId: 'mem001', memberName: '佐藤 太郎', durationSeconds: 3600 },
+                ],
+            },
+        };
+        const transformer = createMockTransformer(resultWithoutWarnings);
+        const { result } = renderHook(() => useFileQueue(transformer));
+
+        const file = new File(['dummy'], 'test.csv', { type: 'text/csv' });
+        act(() => {
+            result.current.addFiles([file]);
+        });
+
+        // missing_group になる（groupNameが空）
+        await waitFor(() => {
+            expect(result.current.queue[0].status).toBe('missing_group');
+        });
+
+        // warningsがundefinedでも空配列にフォールバックされる
+        expect(result.current.queue[0].warnings).toEqual([]);
+    });
+});
+
 describe('useFileQueue — SELECT_GROUP', () => {
     it('selectGroup で groupOverride が設定される', async () => {
         const transformer = createMockTransformer(createParseResult());


### PR DESCRIPTION
## 概要（Why / 目的）
useFileQueueおよびuseAuthフックの機能をより詳細にテストするため、複数のテストケースを追加します。既存の実装の動作を検証し、エッジケースをカバーします。

## 変更内容（What）

### useFileQueue.test.jsx
- **ファイルバリデーション**: CSV以外のファイル、10MBを超えるファイルのエラーハンドリングをテスト
- **パース処理**: パース失敗時のエラーステータス、成功時のreadyステータス、警告の保持をテスト
- **重複チェック**: 既存セッションIDとの重複検出、重複承認フローをテスト
- **ファイル削除**: removeFileメソッドの動作をテスト
- **保存ステータス更新**: saving/saved/save_failed/readyステータスの遷移をテスト
- **複数アイテム操作**: 複数ファイル時の個別ステータス管理、approveDuplicateの選択的適用をテスト
- **SELECT_GROUP分岐**: dateがnullの場合の重複チェックスキップ、undefinedなwarningsのフォールバックをテスト

### useAuth.test.jsx
- **クエリパラメータ保持**: tokenパラメータ以外のクエリパラメータが保持されることをテスト
- **createAuthAdapter**: SASトークンの有無に応じたgetSasToken/isAdminModeの動作をテスト

## 関連（Issue / チケット / Docs）
- 

## 影響範囲・互換性（Impact）
- 破壊的変更: なし
- データ互換（CSV/集計）: 影響なし
- テストのみの変更で、既存の実装に変更はありません

## 動作確認・テスト（How verified）
- [x] 新規テストケースが追加され、useFileQueueおよびuseAuthの主要な機能をカバー
- [x] 既存テストとの互換性を確認

## レビュワーへの補足
- useFileQueueの複雑な状態管理フロー（バリデーション→パース→重複チェック→ステータス遷移）を網羅的にテストしています
- エッジケース（dateがnull、warningsがundefined等）も含めてカバーしています
- createAuthAdapterの新規エクスポートに対応したテストを追加しています

https://claude.ai/code/session_01MZy3yVaprb3KJbUojoJyH1