### PR TITLE
fix(AdminPage): useEffect の非同期処理にクリーンアップ関数を追加

### DIFF
--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -92,8 +92,10 @@ export function AdminPage() {
 
   // 既存セッションIDの取得とグループ一覧の取得
   useEffect(() => {
+    let cancelled = false;
     (async () => {
       const indexResult = await dataFetcher.fetchIndex();
+      if (cancelled) return;
       if (indexResult.ok) {
         const sessionIds = new Set(indexResult.data.groups.flatMap((g) => g.sessionIds));
         setExistingSessionIds(sessionIds);
@@ -106,6 +108,7 @@ export function AdminPage() {
             result: await dataFetcher.fetchSession(sessionId),
           }))
         );
+        if (cancelled) return;
         const loadedSessions = sessionResults
           .filter(({ result }) => result.ok)
           .map(({ result }) => result.data)
@@ -116,6 +119,9 @@ export function AdminPage() {
         );
       }
     })();
+    return () => {
+      cancelled = true;
+    };
   }, [dataFetcher, setExistingSessionIds]);
 
   useEffect(() => {

--- a/tests/react/pages/AdminPage.test.jsx
+++ b/tests/react/pages/AdminPage.test.jsx
@@ -1,5 +1,5 @@
 // AdminPage — ソースファイル保存パスの検証テスト
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { AdminPage } from '../../../src/pages/AdminPage.jsx';
@@ -553,13 +553,15 @@ describe('AdminPage — 非管理者リダイレクト', () => {
     mockIsAdmin = true;
   });
 
-  it('非管理者はダッシュボードにリダイレクトされる', () => {
+  it('非管理者はダッシュボードにリダイレクトされる', async () => {
     render(
       <MemoryRouter>
         <AdminPage />
       </MemoryRouter>
     );
     expect(screen.queryByText('管理者パネル')).not.toBeInTheDocument();
+    // useEffect の非同期処理（fetchIndex → セッション一覧取得）の完了を待つ
+    await act(async () => {});
   });
 });
 


### PR DESCRIPTION
## 概要（Why / 目的）
AdminPage の `useEffect` 内で実行される非同期処理（`fetchIndex` → セッション一覧取得）が、コンポーネントのアンマウント後に state を更新しようとする問題を修正。React の警告を解消し、メモリリークを防止する。

## 変更内容（What）
- `useEffect` に `cancelled` フラグによるクリーンアップ関数を追加し、アンマウント後の `setState` 呼び出しを抑止
- テストコード（非管理者リダイレクトテスト）に `act()` を追加し、非同期処理の完了を適切に待機するよう修正

## 関連（Issue / チケット / Docs）
- Fixes #129

## 影響範囲・互換性（Impact）
- 破壊的変更: なし
- データ互換（CSV/集計）: 影響なし

## 動作確認・テスト（How verified）
- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み

## スクリーンショット / 画面差分（UI変更がある場合）
UI 変更なし

## デプロイ / 運用メモ（必要な場合）
特になし

## レビュワーへの補足
- `cancelled` フラグパターンは React 公式ドキュメントで推奨されているクリーンアップ手法です
- `fetchIndex` と `fetchSession` の2箇所の非同期完了後にそれぞれ `cancelled` チェックを挿入しています
