### PR TITLE
fix(ui): ダッシュボードのグループ/メンバー表示スタイルを統一

### DIFF
--- a/src/components/GroupList.jsx
+++ b/src/components/GroupList.jsx
@@ -8,25 +8,23 @@ const GroupRow = memo(function GroupRow({ group, onNavigate, index }) {
         <div
             data-testid="group-row"
             onClick={() => onNavigate(`/groups/${group.id}`)}
-            className="list-accent-primary p-5 hover:bg-surface-muted cursor-pointer flex justify-between items-center group animate-fade-in-up"
+            className="list-accent-primary p-4 px-6 hover:bg-surface-muted cursor-pointer flex justify-between items-center group animate-fade-in-up border-b border-border-light min-h-[73px]"
             style={{ animationDelay: `${index * 60}ms` }}
         >
-            <div>
-                <h3 className="font-semibold text-text-primary mb-2">{group.name}</h3>
-                <div className="flex items-center text-sm text-text-secondary gap-6">
-                    <span className="flex items-center gap-1.5 bg-surface-muted px-2.5 py-1 rounded-md">
-                        <span className="font-bold text-text-primary font-display">
-                            {group.sessionRevisions.length}
-                        </span>{' '}
-                        回開催
-                    </span>
-                    <span className="flex items-center gap-1.5">
-                        <Clock className="w-4 h-4 text-text-muted" />
-                        <span className="font-display">{formatDuration(group.totalDurationSeconds)}</span>
-                    </span>
-                </div>
+            <h3 className="font-semibold text-text-primary">{group.name}</h3>
+            <div className="flex items-center text-sm text-text-secondary gap-4">
+                <span className="flex items-center gap-1.5 bg-surface-muted px-2.5 py-1 rounded-md">
+                    <span className="font-semibold text-text-primary font-display">
+                        {group.sessionRevisions.length}
+                    </span>{' '}
+                    回開催
+                </span>
+                <span className="flex items-center gap-1.5 w-24 justify-end">
+                    <Clock className="w-4 h-4 text-text-muted" />
+                    <span className="font-display">{formatDuration(group.totalDurationSeconds)}</span>
+                </span>
+                <ChevronRight className="w-4 h-4 text-text-muted group-hover:text-primary-600 transition-colors" />
             </div>
-            <ChevronRight className="w-4 h-4 text-text-muted group-hover:text-primary-600 group-hover:translate-x-0.5 transition-all" />
         </div>
     );
 });
@@ -35,14 +33,14 @@ export function GroupList({ groups }) {
     const navigate = useNavigate();
 
     return (
-        <div className="card-base overflow-hidden card-interactive">
-            <div className="p-6 border-b border-border-light">
+        <div className="card-base overflow-hidden">
+            <div className="p-6 border-b border-border-light flex items-center min-h-[83px]">
                 <h2 className="text-lg font-bold text-text-primary flex items-center gap-2">
                     <Users className="w-5 h-5 text-primary-600" />
                     グループ
                 </h2>
             </div>
-            <div className="divide-y divide-border-light">
+            <div>
                 {groups.map((group, index) => (
                     <GroupRow key={group.id} group={group} onNavigate={navigate} index={index} />
                 ))}

--- a/src/components/MemberList.jsx
+++ b/src/components/MemberList.jsx
@@ -21,11 +21,11 @@ const MemberRow = memo(function MemberRow({ member, onNavigate }) {
                 <h3 className="font-medium text-text-primary">{member.name}</h3>
             </div>
             <div className="flex items-center text-sm text-text-secondary gap-4">
-                <span className="flex items-center gap-1.5 bg-surface-muted px-2 py-1 rounded">
+                <span className="flex items-center gap-1.5 bg-surface-muted px-2.5 py-1 rounded-md">
                     <span className="font-semibold text-text-primary font-display">
                         {member.sessionRevisions.length}
                     </span>{' '}
-                    回
+                    回参加
                 </span>
                 <span className="flex items-center gap-1.5 w-24 justify-end">
                     <Clock className="w-4 h-4 text-text-muted" />


### PR DESCRIPTION
## 概要（Why / 目的）

ダッシュボードの GroupList と MemberList で、ホバー動作・バッジスタイル・行高さ・ヘッダー高さに不統一があり、一貫した UX を提供するために修正する。

## 変更内容（What）

### GroupList.jsx
- `card-interactive` を削除（カード全体のホバー浮き上がりを除去、行単位ホバーで十分）
- Chevron の `translate-x-0.5` + `transition-all` → `transition-colors` に変更（移動アニメーション除去）
- バッジの `font-bold` → `font-semibold` に統一
- 2行レイアウト → 1行レイアウトに変更（MemberRow と同じ構造）
- `p-5` → `p-4 px-6` + `min-h-[73px]` で行高さを MemberRow（73px）と統一
- ヘッダーに `flex items-center min-h-[83px]` を追加し MemberList ヘッダー（83px）と統一
- `divide-y` → 各行に `border-b` で MemberRow と同じボーダー方式に統一

### MemberList.jsx
- バッジの `px-2 rounded` → `px-2.5 rounded-md` に統一
- セッション回数ラベル `回` → `回参加` に変更（GroupList の `回開催` と対応する動詞を明示）

## 関連（Issue / チケット / Docs）
- なし

## 影響範囲・互換性（Impact）
- 破壊的変更: なし
- データ互換（CSV/集計）: なし
- 影響範囲: ダッシュボード画面のグループ一覧・メンバー一覧の表示のみ

## 動作確認・テスト（How verified）
- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み（lint / 332テスト全通過 / ビルド成功）

### Playwright による実測確認

| 要素 | 修正前 Group / Member | 修正後 |
|------|----------------------|--------|
| ヘッダー | 77px / 83px | **83px / 83px** |
| コンテンツ行 | 61px / 73px | **73px / 73px** |

## スクリーンショット / 画面差分（UI変更がある場合）

修正後のダッシュボード：グループ行とメンバー行の高さ・バッジスタイルが統一されている。

## デプロイ / 運用メモ（必要な場合）
- CSS のみの変更のため、特別なデプロイ手順は不要

## レビュワーへの補足
- 意図的に維持した差異: アクセントカラー（teal vs coral）、アバター（メンバーのみ）、検索（メンバーのみ）、入場アニメーション（グループのみ）、レイアウト構造（1行 vs アバター付き1行）
