### PR TITLE
fix(ui): メンバー詳細画面のデザイン改善（#141）

### DIFF
--- a/src/pages/MemberDetailPage.jsx
+++ b/src/pages/MemberDetailPage.jsx
@@ -343,6 +343,16 @@ export function MemberDetailPage() {
                     <div className="border-t border-border-light">
                       <div className="overflow-x-auto">
                         <table className="w-full">
+                          <thead>
+                            <tr>
+                              <th scope="col" className="sr-only">
+                                日付
+                              </th>
+                              <th scope="col" className="sr-only">
+                                参加時間
+                              </th>
+                            </tr>
+                          </thead>
                           <tbody className="divide-y divide-border-light">
                             {group.sessions.map((session) => {
                               const parts = formatSessionParts(session);

--- a/tests/react/pages/MemberDetailPage.test.jsx
+++ b/tests/react/pages/MemberDetailPage.test.jsx
@@ -141,6 +141,9 @@ describe('MemberDetailPage', () => {
     expect(screen.getByText('振り返り会')).toBeInTheDocument();
     // グループ名がサマリーカードに表示される
     expect(screen.getByText(/フロントエンド勉強会/)).toBeInTheDocument();
+    // セッション履歴テーブルの列見出しが存在する
+    expect(screen.getByRole('columnheader', { name: '日付' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: '参加時間' })).toBeInTheDocument();
   });
 
   it('存在しないメンバーIDの場合にエラーを表示すること', async () => {


### PR DESCRIPTION
## 概要（Why / 目的）
メンバー詳細画面（`MemberDetailPage`）の期セレクター・アコーディオン・セッション表示に視認性と一貫性の課題があったため、Issue #141 に基づきデザインを改善する。

## 変更内容（What）
- **期セレクター**: `rounded-lg` → `rounded-r-lg` で左辺を直線化、選択時背景を `bg-white shadow-sm` に変更してカード状に浮き上がらせ、`border-l-4` → `border-l-3` に微調整
- **ヘッダーカード**: `rounded-t-none` を追加し上辺を直線化、アクセントグラデーション帯が角丸でクリップされる三日月表示を解消
- **アコーディオンヘッダー**: `p-6` → `px-6 py-3.5` でセッション行との高さ比率を約1.2:1に改善
- **セッション表示**: `formatSessionLabel` → `formatSessionParts` に変更し日付を先頭に固定表示、別名を `text-text-secondary` で視覚的に分離、`thead` を削除

## 関連（Issue / チケット / Docs）
- Closes #141

## 影響範囲・互換性（Impact）
- 破壊的変更: なし
- データ互換（CSV/集計）: なし（UI変更のみ）

## 動作確認・テスト（How verified）
- [x] ビルド確認済み
- [x] 全332ユニットテスト合格（Vitest）
- [x] ESLint クリーン
- [x] Playwright でスクリーンショット撮影し視覚的に確認済み

## スクリーンショット / 画面差分（UI変更がある場合）
Playwright で撮影した修正後のメンバー詳細画面（アコーディオン展開状態）:
- ヘッダーカード上辺が直線でアクセント帯が端まで均一
- 期セレクターの選択状態が白背景+影で明確
- アコーディオンヘッダーとセッション行の高さバランスが改善
- セッション表示で日付が左端固定、別名がグレーテキストで後続

## デプロイ / 運用メモ（必要な場合）
- 特になし

## レビュワーへの補足
- `formatSessionLabel` は `GroupDetailPage.jsx` にも同名の関数があるが、別ファイルの独立した定義のため影響なし
