### PR TITLE
fix(ui): グループ詳細画面へメンバー詳細改善を横展開（#144）

### DIFF
--- a/src/pages/GroupDetailPage.jsx
+++ b/src/pages/GroupDetailPage.jsx
@@ -14,8 +14,12 @@ import {
 
 const fetcher = new DataFetcher();
 
-function formatSessionLabel(session) {
-  return session.title ? `${session.title} - ${session.date}` : session.date;
+/**
+ * セッションの日付と別名を分離して返す
+ * 日付を先頭に固定し、別名がある場合は別要素として返す
+ */
+function formatSessionParts(session) {
+  return { date: session.date, title: session.title || null };
 }
 
 /**
@@ -209,7 +213,7 @@ export function GroupDetailPage() {
       </Link>
 
       {/* グループヘッダーカード — アクセント帯付き */}
-      <div className="card-base overflow-hidden animate-fade-in-up">
+      <div className="card-base rounded-t-none overflow-hidden animate-fade-in-up">
         <div className="h-1 bg-gradient-to-r from-primary-500 via-primary-400 to-accent-400" />
         <div className="p-8 flex items-center gap-6">
           <div className="w-16 h-16 rounded-2xl bg-gradient-to-br from-primary-100 to-primary-200 flex items-center justify-center text-primary-700">
@@ -242,20 +246,20 @@ export function GroupDetailPage() {
                 key={period.label}
                 onClick={() => setSelectedPeriodLabel(period.label)}
                 aria-pressed={isSelected}
-                className={`w-full text-left px-4 py-3 rounded-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
+                className={`w-full text-left px-4 py-3 rounded-r-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
                   isSelected
-                    ? 'bg-primary-50 border-l-4 border-l-primary-500'
-                    : 'hover:bg-surface-muted border-l-4 border-l-transparent'
+                    ? 'bg-white shadow-sm border-l-3 border-l-primary-500'
+                    : 'hover:bg-surface-muted border-l-3 border-l-transparent'
                 }`}
               >
-                <div className="text-sm font-bold text-text-primary">{period.label}</div>
-                <div className="flex items-center gap-3 mt-1 text-xs text-text-secondary">
+                <div className="text-base font-bold text-text-primary">{period.label}</div>
+                <div className="flex items-center gap-3 mt-1 text-sm text-text-secondary">
                   <span className="flex items-center gap-1">
-                    <Calendar className="w-3 h-3 text-text-muted" aria-hidden="true" />
+                    <Calendar className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
                     <span className="font-display font-semibold">{period.totalSessions}</span>回
                   </span>
                   <span className="flex items-center gap-1">
-                    <Clock className="w-3 h-3 text-text-muted" aria-hidden="true" />
+                    <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
                     <span className="font-display">{formatDuration(period.totalDurationSeconds)}</span>
                   </span>
                 </div>
@@ -278,7 +282,7 @@ export function GroupDetailPage() {
                 <button
                   onClick={() => toggleSession(session.sessionId)}
                   aria-expanded={isExpanded}
-                  className="w-full p-6 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                  className="w-full px-6 py-3.5 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
                 >
                   <div className="flex items-center gap-4">
                     {isExpanded ? (
@@ -288,7 +292,17 @@ export function GroupDetailPage() {
                     )}
                     <div>
                       <h3 className="text-base font-bold text-text-primary">
-                        {formatSessionLabel(session)}
+                        {(() => {
+                          const parts = formatSessionParts(session);
+                          return (
+                            <>
+                              <span>{parts.date}</span>
+                              {parts.title && (
+                                <span className="ml-2 font-normal text-text-secondary">{parts.title}</span>
+                              )}
+                            </>
+                          );
+                        })()}
                       </h3>
                       <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
                         <span className="flex items-center gap-1.5">
@@ -315,9 +329,13 @@ export function GroupDetailPage() {
                       <div className="overflow-x-auto">
                         <table className="w-full">
                           <thead>
-                            <tr className="border-b border-border-light bg-surface-muted text-left text-xs text-text-muted uppercase tracking-wider">
-                              <th className="px-6 py-3 font-medium">名前</th>
-                              <th className="px-6 py-3 font-medium text-right">参加時間</th>
+                            <tr>
+                              <th scope="col" className="sr-only">
+                                名前
+                              </th>
+                              <th scope="col" className="sr-only">
+                                参加時間
+                              </th>
                             </tr>
                           </thead>
                           <tbody className="divide-y divide-border-light">

--- a/tests/react/pages/GroupDetailPage.test.jsx
+++ b/tests/react/pages/GroupDetailPage.test.jsx
@@ -191,11 +191,10 @@ describe('GroupDetailPage', () => {
     // 期サマリーが表示される（2025年度 下期 = 2026年1月）
     expect(screen.getByText('2025年度 下期')).toBeInTheDocument();
 
-    // セッション見出しが表示される（日付降順）
-    const headings = screen.getAllByRole('heading', { level: 3 });
-    const dates = headings.map((h) => h.textContent);
-    expect(dates[0]).toBe('第3回 React入門 - 2026-01-20');
-    expect(dates[1]).toBe('2026-01-15');
+    // セッション見出しが表示される（日付降順、日付が先頭・別名が後続で表示される）
+    expect(screen.getByText('2026-01-20')).toBeInTheDocument();
+    expect(screen.getByText('第3回 React入門')).toBeInTheDocument();
+    expect(screen.getByText('2026-01-15')).toBeInTheDocument();
   });
 
   it('セッションをクリックして参加者テーブルを展開・折りたたみできること', async () => {
@@ -241,6 +240,9 @@ describe('GroupDetailPage', () => {
     // セッション1件のみなのでデフォルト展開
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(screen.getByText('佐藤 一郎')).toBeInTheDocument();
+    // 参加者テーブルの列見出しが存在する
+    expect(screen.getByRole('columnheader', { name: '名前' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: '参加時間' })).toBeInTheDocument();
   });
 
   it('存在しないグループIDの場合にエラーを表示すること', async () => {


### PR DESCRIPTION
## 概要（Why / 目的）
PR #143 で実施したメンバー詳細画面の UI/UX・アクセシビリティ改善を、グループ詳細画面にも横展開して詳細画面間の体験を統一する。

## 変更内容（What）
- `formatSessionLabel` → `formatSessionParts` に変更し、セッション見出しで日付を先頭・別名を副次表示に分離
- ヘッダーカードに `rounded-t-none` を追加（アクセント帯との一体感）
- 期ボタンのスタイル統一（`rounded-r-lg`, `border-l-3`, `bg-white shadow-sm`）
- テキストサイズ（`text-sm` → `text-base`）・アイコンサイズ（`w-3` → `w-3.5`）をメンバー詳細と統一
- アコーディオンボタンのパディング調整（`p-6` → `px-6 py-3.5`）
- テーブルヘッダーを `sr-only` + `scope="col"` に変更（支援技術向けセマンティクス）
- テストを更新（日付/タイトル分離確認、`columnheader` ロール確認追加）

## 関連（Issue / チケット / Docs）
- Closes #144
- 参照: #141, #143

## 影響範囲・互換性（Impact）
- 破壊的変更: なし
- データ互換（CSV/集計）: なし
- 影響範囲: グループ詳細画面（`#/groups/:groupId`）のみ

## 動作確認・テスト（How verified）
- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み（lint + test:coverage + build 全通過、332テスト通過）

## スクリーンショット / 画面差分（UI変更がある場合）
CI の E2E テストで確認予定

## デプロイ / 運用メモ（必要な場合）
- 特になし

## レビュワーへの補足
- PR #143（MemberDetailPage）の差分を基準に、同等のスタイル・セマンティクスを GroupDetailPage に適用
- テーブルヘッダーは視覚的に非表示（`sr-only`）だがスクリーンリーダーからは参照可能
