### PR TITLE
fix(ui): グループカードの長いグループ名によるレイアウト崩れを修正

### DIFF
--- a/src/components/GroupList.jsx
+++ b/src/components/GroupList.jsx
@@ -3,16 +3,36 @@ import { formatDuration } from '../utils/format-duration';
 import { Users, Clock, ChevronRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+/** ホバー時にテキストが省略されている場合のみツールチップを有効化 */
+function handleTruncateMouseEnter(e) {
+    const wrapper = e.currentTarget;
+    const textEl = wrapper.querySelector('.truncate');
+    if (textEl && textEl.scrollWidth > textEl.clientWidth) {
+        wrapper.setAttribute('data-truncated', '');
+    }
+}
+
+function handleTruncateMouseLeave(e) {
+    e.currentTarget.removeAttribute('data-truncated');
+}
+
 const GroupRow = memo(function GroupRow({ group, onNavigate, index }) {
     return (
         <div
             data-testid="group-row"
             onClick={() => onNavigate(`/groups/${group.id}`)}
-            className="list-accent-primary p-4 px-6 hover:bg-surface-muted cursor-pointer flex justify-between items-center group animate-fade-in-up border-b border-border-light min-h-[73px]"
+            className="list-accent-primary p-4 px-6 hover:bg-surface-muted cursor-pointer flex justify-between items-center group animate-fade-in-up border-b border-border-light last:border-b-0 last:rounded-b-2xl min-h-[73px]"
             style={{ animationDelay: `${index * 60}ms` }}
         >
-            <h3 className="font-semibold text-text-primary">{group.name}</h3>
-            <div className="flex items-center text-sm text-text-secondary gap-4">
+            <div
+                className="min-w-0 flex-1 truncate-with-tooltip"
+                data-fulltext={group.name}
+                onMouseEnter={handleTruncateMouseEnter}
+                onMouseLeave={handleTruncateMouseLeave}
+            >
+                <h3 className="font-semibold text-text-primary truncate">{group.name}</h3>
+            </div>
+            <div className="flex items-center text-sm text-text-secondary gap-4 shrink-0">
                 <span className="flex items-center gap-1.5 bg-surface-muted px-2.5 py-1 rounded-md">
                     <span className="font-semibold text-text-primary font-display">
                         {group.sessionRevisions.length}
@@ -33,7 +53,7 @@ export function GroupList({ groups }) {
     const navigate = useNavigate();
 
     return (
-        <div className="card-base overflow-hidden">
+        <div className="card-base">
             <div className="p-6 border-b border-border-light flex items-center min-h-[83px]">
                 <h2 className="text-lg font-bold text-text-primary flex items-center gap-2">
                     <Users className="w-5 h-5 text-primary-600" />

--- a/src/components/MemberList.jsx
+++ b/src/components/MemberList.jsx
@@ -14,13 +14,13 @@ const MemberRow = memo(function MemberRow({ member, onNavigate }) {
             onClick={() => onNavigate(`/members/${member.id}`)}
             className="list-accent-warm p-4 px-6 hover:bg-surface-muted cursor-pointer flex justify-between items-center group border-b border-border-light h-full"
         >
-            <div className="flex items-center gap-4">
-                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary-100 to-primary-200 flex items-center justify-center text-primary-700 font-bold text-sm">
+            <div className="flex items-center gap-4 min-w-0">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary-100 to-primary-200 flex items-center justify-center text-primary-700 font-bold text-sm shrink-0">
                     {member.name.charAt(0)}
                 </div>
-                <h3 className="font-medium text-text-primary">{member.name}</h3>
+                <h3 className="font-medium text-text-primary truncate">{member.name}</h3>
             </div>
-            <div className="flex items-center text-sm text-text-secondary gap-4">
+            <div className="flex items-center text-sm text-text-secondary gap-4 shrink-0">
                 <span className="flex items-center gap-1.5 bg-surface-muted px-2.5 py-1 rounded-md">
                     <span className="font-semibold text-text-primary font-display">
                         {member.sessionRevisions.length}

--- a/src/index.css
+++ b/src/index.css
@@ -156,6 +156,57 @@
     animation: shimmer 1.5s infinite;
     @apply rounded-lg;
   }
+
+  /* テキスト省略時のツールチップ */
+  .truncate-with-tooltip {
+    position: relative;
+  }
+
+  .truncate-with-tooltip::after {
+    content: attr(data-fulltext);
+    position: absolute;
+    left: 0;
+    top: calc(100% + 8px);
+    z-index: 50;
+    padding: 0.375rem 0.75rem;
+    background-color: var(--color-text-primary);
+    color: white;
+    font-size: 0.875rem;
+    line-height: 1.4;
+    border-radius: 0.5rem;
+    white-space: normal;
+    max-width: 280px;
+    width: max-content;
+    word-break: break-word;
+    box-shadow: var(--shadow-md);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 150ms ease, visibility 150ms ease;
+    pointer-events: none;
+  }
+
+  /* ツールチップの矢印（上向き） */
+  .truncate-with-tooltip::before {
+    content: '';
+    position: absolute;
+    left: 1rem;
+    top: calc(100% + 4px);
+    z-index: 50;
+    border-width: 4px;
+    border-style: solid;
+    border-color: transparent transparent var(--color-text-primary) transparent;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 150ms ease, visibility 150ms ease;
+    pointer-events: none;
+  }
+
+  .truncate-with-tooltip[data-truncated]:hover::after,
+  .truncate-with-tooltip[data-truncated]:hover::before {
+    opacity: 1;
+    visibility: visible;
+    transition-delay: 300ms; /* 表示は300ms遅延、非表示は即座 */
+  }
 }
 
 /* アニメーション軽減設定への対応 */
@@ -175,6 +226,11 @@
   }
 
   .accordion-panel {
+    transition: none !important;
+  }
+
+  .truncate-with-tooltip::after,
+  .truncate-with-tooltip::before {
     transition: none !important;
   }
 }

--- a/src/pages/GroupDetailPage.jsx
+++ b/src/pages/GroupDetailPage.jsx
@@ -220,7 +220,7 @@ export function GroupDetailPage() {
             <Users className="w-8 h-8" aria-hidden="true" />
           </div>
           <div>
-            <h2 className="text-xl font-bold text-text-primary">{group.name}</h2>
+            <h2 className="text-xl font-bold text-text-primary break-words">{group.name}</h2>
             <div className="flex items-center gap-4 mt-2 text-sm text-text-secondary">
               <span className="flex items-center gap-1.5">
                 <Calendar className="w-4 h-4 text-text-muted" aria-hidden="true" />

--- a/tests/react/components/GroupList.test.jsx
+++ b/tests/react/components/GroupList.test.jsx
@@ -55,6 +55,59 @@ describe('GroupList', () => {
     }
   });
 
+  it('長いグループ名に truncate と tooltip が適用されること', () => {
+    const longNameGroups = [
+      {
+        id: 'g-long',
+        name: '複合ＳＩ・ソリューション勉強会',
+        totalDurationSeconds: 3600,
+        sessionRevisions: ['s1/0'],
+      },
+    ];
+    renderGroupList(longNameGroups);
+
+    const heading = screen.getByText('複合ＳＩ・ソリューション勉強会');
+    expect(heading).toHaveClass('truncate');
+
+    // ツールチップ用の data-fulltext 属性がラッパーに設定されていること
+    const tooltipWrapper = heading.closest('[data-fulltext]');
+    expect(tooltipWrapper).toHaveAttribute('data-fulltext', '複合ＳＩ・ソリューション勉強会');
+    expect(tooltipWrapper).toHaveClass('truncate-with-tooltip');
+  });
+
+  it('テキスト省略時にホバーで data-truncated が付与されること', () => {
+    renderGroupList();
+
+    const heading = screen.getByText('フロントエンド勉強会');
+    const tooltipWrapper = heading.closest('[data-fulltext]');
+    const truncateEl = tooltipWrapper.querySelector('.truncate');
+
+    // scrollWidth > clientWidth をモックして省略状態をシミュレート
+    Object.defineProperty(truncateEl, 'scrollWidth', { value: 200, configurable: true });
+    Object.defineProperty(truncateEl, 'clientWidth', { value: 100, configurable: true });
+
+    fireEvent.mouseEnter(tooltipWrapper);
+    expect(tooltipWrapper).toHaveAttribute('data-truncated');
+
+    fireEvent.mouseLeave(tooltipWrapper);
+    expect(tooltipWrapper).not.toHaveAttribute('data-truncated');
+  });
+
+  it('テキスト非省略時にホバーしても data-truncated が付与されないこと', () => {
+    renderGroupList();
+
+    const heading = screen.getByText('フロントエンド勉強会');
+    const tooltipWrapper = heading.closest('[data-fulltext]');
+    const truncateEl = tooltipWrapper.querySelector('.truncate');
+
+    // scrollWidth === clientWidth（省略なし）
+    Object.defineProperty(truncateEl, 'scrollWidth', { value: 100, configurable: true });
+    Object.defineProperty(truncateEl, 'clientWidth', { value: 100, configurable: true });
+
+    fireEvent.mouseEnter(tooltipWrapper);
+    expect(tooltipWrapper).not.toHaveAttribute('data-truncated');
+  });
+
   it('開催回数と参加時間が表示されること', () => {
     renderGroupList();
 


### PR DESCRIPTION
## 概要（Why / 目的）

ダッシュボードのグループ一覧で、長いグループ名（例:「複合ＳＩ・ソリューション勉強会」）が折り返され、カード行の高さが不統一になるレイアウト崩れを修正する。

## 変更内容（What）

- **GroupRow**: `truncate` で長いグループ名を省略表示し、CSS ツールチップ（`::after` 疑似要素）でホバー時にフルネームを表示
- **省略検知**: `mouseenter` 時に `scrollWidth > clientWidth` を比較し、テキストが実際に省略されている場合のみツールチップを有効化（`data-truncated` 属性を動的に付与）
- **MemberRow**: 同じ構造の潜在的問題を予防するため `min-w-0` + `truncate` + `shrink-0` を追加
- **GroupDetailPage**: ヘッダーのグループ名に `break-words` を追加して自然に折り返し
- **CSS**: `.truncate-with-tooltip` ユーティリティを `@layer utilities` に追加、`prefers-reduced-motion` にも対応
- **overflow-hidden 削除**: ツールチップが親要素にクリップされるのを防止、最終行の角丸は `last:rounded-b-2xl` で維持

## 関連（Issue / チケット / Docs）

- Fixes #147

## 影響範囲・互換性（Impact）

- 破壊的変更: なし
- データ互換（CSV/集計）: なし
- 影響する画面: ダッシュボード（グループ一覧・メンバー一覧）、グループ詳細画面ヘッダー

## 動作確認・テスト（How verified）

- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み（lint + test:coverage + build 全パス、テスト 335件）

## スクリーンショット / 画面差分（UI変更がある場合）

<!-- デプロイ後に目視確認予定 -->

## デプロイ / 運用メモ（必要な場合）

- 通常の静的ファイルデプロイのみ。設定変更不要。

## レビュワーへの補足

- CSS-only ツールチップに JS による省略検知を組み合わせることで、テキストが省略されていない場合のホバー表示を抑制
- `GroupList.jsx` の `handleTruncateMouseEnter`/`handleTruncateMouseLeave` はコンポーネント外のモジュールスコープ関数として定義（`memo` の再レンダリングに影響しない）
