### PR TITLE
fix(ui): グループカードの時間列が折り返す問題を修正 (#151)

### DIFF
--- a/src/components/GroupList.jsx
+++ b/src/components/GroupList.jsx
@@ -39,7 +39,7 @@ const GroupRow = memo(function GroupRow({ group, onNavigate, index }) {
                     </span>{' '}
                     回開催
                 </span>
-                <span className="flex items-center gap-1.5 w-24 justify-end">
+                <span className="flex items-center gap-1.5 whitespace-nowrap">
                     <Clock className="w-4 h-4 text-text-muted" />
                     <span className="font-display">{formatDuration(group.totalDurationSeconds)}</span>
                 </span>


### PR DESCRIPTION
## 概要（Why / 目的）
ダッシュボードのグループカードで、時間列（`w-24` = 96px 固定幅）が「404時間8分」などの長い時間テキストに対して幅不足のため、テキストが折り返してカードの高さが不揃いになる問題を修正する。

## 変更内容（What）
- `GroupList.jsx` の時間列クラスから `w-24 justify-end`（96px 固定幅＋右寄せ）を削除
- `whitespace-nowrap` を追加し、テキストの折り返しを防止
- 親要素の `shrink-0` によりコンテンツ幅に応じた動的サイズ決定に変更

## 関連（Issue / チケット / Docs）
- Fixes #151

## 影響範囲・互換性（Impact）
- 破壊的変更: なし
- データ互換（CSV/集計）: なし（UI のみの変更）

## 動作確認・テスト（How verified）
- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み

## スクリーンショット / 画面差分（UI変更がある場合）
<!-- 開発サーバーで目視確認をお願いします -->

## デプロイ / 運用メモ（必要な場合）
- 特になし

## レビュワーへの補足
- 1行のみの CSS クラス変更。親要素 `shrink-0` により時間列は縮小されず、グループ名側（`flex-1 min-w-0`）が残りの幅を吸収する仕組み
