### PR TITLE
feat(ui): グループ詳細画面のセッションカードに講師名を表示

### DIFF
--- a/src/pages/GroupDetailPage.jsx
+++ b/src/pages/GroupDetailPage.jsx
@@ -14,6 +14,7 @@ import {
     Clock,
     Calendar,
     Users,
+    GraduationCap,
     ChevronDown,
     ChevronRight,
     Trash2,
@@ -164,6 +165,11 @@ export function GroupDetailPage() {
                 const periodEntry = periodMap.get(period.label);
                 periodEntry.totalSessions += 1;
                 periodEntry.totalDurationSeconds += totalDurationSeconds;
+                // 講師 ULID 配列からメンバー名を解決
+                const instructorNames = (session.instructors || [])
+                    .map((id) => memberNameMap.get(id))
+                    .filter(Boolean);
+
                 periodEntry.sessions.push({
                     sessionId: session.sessionId,
                     sessionRef,
@@ -172,6 +178,7 @@ export function GroupDetailPage() {
                     attendeeCount: attendees.length,
                     totalDurationSeconds,
                     attendees,
+                    instructorNames,
                 });
             }
 
@@ -502,6 +509,19 @@ export function GroupDetailPage() {
                                                             );
                                                         })()}
                                                     </h3>
+                                                    {session.instructorNames.length > 0 && (
+                                                        <div className="flex items-center gap-1.5 mt-0.5 text-sm text-text-secondary">
+                                                            <GraduationCap
+                                                                className="w-3.5 h-3.5 text-text-muted"
+                                                                aria-hidden="true"
+                                                            />
+                                                            <span>
+                                                                {session.instructorNames.join(
+                                                                    '、'
+                                                                )}
+                                                            </span>
+                                                        </div>
+                                                    )}
                                                     <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
                                                         <span className="flex items-center gap-1.5">
                                                             <Users


### PR DESCRIPTION
## 概要（Why / 目的）

グループ詳細画面のセッションカードに講師名が表示されておらず、どのセッションにどの講師がいるか一目で分からない。セッションカードに講師情報を表示し、ユーザーの利便性を向上させる。

## 変更内容（What）

- 期別データ構築時に `session.instructors` の ULID 配列から `memberNameMap` で講師名を解決し `instructorNames` を生成
- セッションカードのセッション名の下に `GraduationCap` アイコン + 講師名（読点区切り）を表示
- 講師 0 名の場合は講師行を非表示
- テスト追加：講師名表示/非表示の検証（2ケース）

## 関連（Issue / チケット / Docs）

- Closes #162
- 親 Issue: #158

## 影響範囲・互換性（Impact）

- 破壊的変更: なし
- データ互換（CSV/集計）: なし（既存の `instructors` フィールドを読み取るのみ）

## 動作確認・テスト（How verified）

- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み

## スクリーンショット / 画面差分（UI変更がある場合）

セッションカードのセッション名の下に講師アイコン + 講師名が表示される。講師がいない場合は何も表示されない。

## デプロイ / 運用メモ（必要な場合）

- 特になし

## レビュワーへの補足

- `GraduationCap` アイコン（lucide-react）を講師表示用に採用
- 講師名の区切りは日本語の読点「、」を使用
- `session.instructors` が未定義の場合も `|| []` でフォールバック
