### PR TITLE
feat: メンバー詳細画面に講師履歴セクションを追加 (#163)

### DIFF
--- a/e2e/dashboard.spec.js
+++ b/e2e/dashboard.spec.js
@@ -255,7 +255,7 @@ test.describe('メンバー詳細画面 — グループ別表示', () => {
     await expect(expandedTables).toHaveCount(0);
   });
 
-  test('グループが1つのみのメンバーではデフォルトで展開されること', async ({ page }) => {
+  test('グループが1つのみのメンバーでも初期状態でアコーディオンが閉じていること', async ({ page }) => {
     const index = await fetchIndex();
     const member = index.members.find(
       (candidate) => getMemberGroups(index, candidate).length === 1
@@ -269,9 +269,8 @@ test.describe('メンバー詳細画面 — グループ別表示', () => {
     // グループ名が表示される（画面準備完了を確認）
     await expect(page.getByRole('heading', { name: memberGroups[0].name, level: 3 })).toBeVisible();
 
-    // 単一グループのメンバーでは初期状態でテーブルが表示されている
-    await expect(page.getByRole('heading', { name: memberGroups[0].name, level: 3 })).toBeVisible();
-    await expect(page.locator('[data-section="attendance"] .accordion-panel[data-expanded="true"] table')).toHaveCount(1);
+    // 全アコーディオンがデフォルトで閉じている
+    await expect(page.locator('[data-section="attendance"] .accordion-panel[data-expanded="true"] table')).toHaveCount(0);
   });
 
   test('複数のグループカードを同時に展開できること', async ({ page }) => {

--- a/src/pages/MemberDetailPage.jsx
+++ b/src/pages/MemberDetailPage.jsx
@@ -29,12 +29,9 @@ function extractDate(startedAt) {
 export function MemberDetailPage() {
   const { memberId } = useParams();
   const [member, setMember] = useState(null);
-  const [periodAttendances, setPeriodAttendances] = useState([]);
-  const [instructorHistory, setInstructorHistory] = useState([]);
+  const [unifiedPeriods, setUnifiedPeriods] = useState([]);
   const [selectedPeriodLabel, setSelectedPeriodLabel] = useState(null);
-  const [selectedInstructorPeriodLabel, setSelectedInstructorPeriodLabel] = useState(null);
   const [expandedGroups, setExpandedGroups] = useState(new Set());
-  const [expandedInstructorGroups, setExpandedInstructorGroups] = useState(new Set());
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -79,8 +76,10 @@ export function MemberDetailPage() {
         return;
       }
 
-      // 第1段: 期別にグルーピング（V2: sessionRef ベース）
+      // 第1段: 期別にグルーピング（出席 + 講師を統合）
       const periodMap = new Map();
+
+      // 出席履歴を期別に集計
       for (let i = 0; i < sessionResults.length; i++) {
         const result = sessionResults[i];
         if (!result.ok) continue;
@@ -99,7 +98,9 @@ export function MemberDetailPage() {
             sortKey: period.sortKey,
             totalSessions: 0,
             totalDurationSeconds: 0,
+            totalInstructorSessions: 0,
             sessions: [],
+            instructorSessions: [],
           });
         }
         const periodEntry = periodMap.get(period.label);
@@ -123,9 +124,48 @@ export function MemberDetailPage() {
         });
       }
 
-      // 第2段: 各期内でグループ別にグルーピング
+      // 講師履歴を期別に集計（同じ periodMap にマージ）
+      for (let i = 0; i < sessionResults.length; i++) {
+        const result = sessionResults[i];
+        if (!result.ok) continue;
+        const session = result.data;
+        const instructors = session.instructors || [];
+        if (!instructors.includes(memberId)) continue;
+
+        const ref = found.sessionRevisions[i];
+        const resolvedGroup = sessionGroupMap.get(ref);
+        if (!resolvedGroup) continue;
+
+        const date = extractDate(session.startedAt);
+        const period = getFiscalPeriod(date);
+        if (!periodMap.has(period.label)) {
+          periodMap.set(period.label, {
+            label: period.label,
+            fiscalYear: period.fiscalYear,
+            half: period.half,
+            sortKey: period.sortKey,
+            totalSessions: 0,
+            totalDurationSeconds: 0,
+            totalInstructorSessions: 0,
+            sessions: [],
+            instructorSessions: [],
+          });
+        }
+        const periodEntry = periodMap.get(period.label);
+        periodEntry.totalInstructorSessions += 1;
+        periodEntry.instructorSessions.push({
+          sessionId: session.sessionId,
+          groupId: resolvedGroup.groupId,
+          groupName: resolvedGroup.groupName,
+          date,
+          title: session.title,
+        });
+      }
+
+      // 第2段: 各期内でグループ別にグルーピング（出席・講師それぞれ）
       const periods = Array.from(periodMap.values());
       for (const period of periods) {
+        // 出席グループ
         const groupMap = new Map();
         for (const session of period.sessions) {
           if (!groupMap.has(session.groupId)) {
@@ -145,100 +185,47 @@ export function MemberDetailPage() {
             durationSeconds: session.durationSeconds,
           });
         }
-
         const grouped = Array.from(groupMap.values());
         for (const group of grouped) {
           group.sessions.sort((a, b) => b.date.localeCompare(a.date));
           group.sessionCount = group.sessions.length;
         }
         grouped.sort((a, b) => a.groupName.localeCompare(b.groupName, 'ja'));
-
         period.groupAttendances = grouped;
-      }
 
-      // 期を降順ソート（最新が先頭）
-      periods.sort((a, b) => b.sortKey - a.sortKey);
-
-      setPeriodAttendances(periods);
-
-      // デフォルトで最新の期を選択
-      if (periods.length > 0) {
-        setSelectedPeriodLabel(periods[0].label);
-      }
-
-      // 選択した期のグループが1つのみの場合はデフォルトで展開
-      if (periods.length > 0 && periods[0].groupAttendances.length === 1) {
-        setExpandedGroups(new Set([periods[0].groupAttendances[0].groupId]));
-      }
-
-      // 講師履歴: instructors 配列に当該メンバーIDが含まれるセッションを抽出
-      const instructorPeriodMap = new Map();
-      for (let i = 0; i < sessionResults.length; i++) {
-        const result = sessionResults[i];
-        if (!result.ok) continue;
-        const session = result.data;
-        const instructors = session.instructors || [];
-        if (!instructors.includes(memberId)) continue;
-
-        const ref = found.sessionRevisions[i];
-        const resolvedGroup = sessionGroupMap.get(ref);
-        if (!resolvedGroup) continue;
-
-        const date = extractDate(session.startedAt);
-        const period = getFiscalPeriod(date);
-        if (!instructorPeriodMap.has(period.label)) {
-          instructorPeriodMap.set(period.label, {
-            label: period.label,
-            sortKey: period.sortKey,
-            totalSessions: 0,
-            sessions: [],
-          });
-        }
-        const periodEntry = instructorPeriodMap.get(period.label);
-        periodEntry.totalSessions += 1;
-        periodEntry.sessions.push({
-          sessionId: session.sessionId,
-          groupId: resolvedGroup.groupId,
-          groupName: resolvedGroup.groupName,
-          date,
-          title: session.title,
-        });
-      }
-
-      // 講師履歴: 各期内でグループ別にグルーピング
-      const instructorPeriods = Array.from(instructorPeriodMap.values());
-      for (const period of instructorPeriods) {
-        const groupMap = new Map();
-        for (const session of period.sessions) {
-          if (!groupMap.has(session.groupId)) {
-            groupMap.set(session.groupId, {
+        // 講師グループ
+        const instructorGroupMap = new Map();
+        for (const session of period.instructorSessions) {
+          if (!instructorGroupMap.has(session.groupId)) {
+            instructorGroupMap.set(session.groupId, {
               groupId: session.groupId,
               groupName: session.groupName,
               sessions: [],
             });
           }
-          groupMap.get(session.groupId).sessions.push({
+          instructorGroupMap.get(session.groupId).sessions.push({
             sessionId: session.sessionId,
             date: session.date,
             title: session.title,
           });
         }
-        const grouped = Array.from(groupMap.values());
-        for (const group of grouped) {
+        const instructorGrouped = Array.from(instructorGroupMap.values());
+        for (const group of instructorGrouped) {
           group.sessions.sort((a, b) => b.date.localeCompare(a.date));
           group.sessionCount = group.sessions.length;
         }
-        grouped.sort((a, b) => a.groupName.localeCompare(b.groupName, 'ja'));
-        period.groupInstructions = grouped;
+        instructorGrouped.sort((a, b) => a.groupName.localeCompare(b.groupName, 'ja'));
+        period.groupInstructions = instructorGrouped;
       }
-      instructorPeriods.sort((a, b) => b.sortKey - a.sortKey);
-      setInstructorHistory(instructorPeriods);
 
-      if (instructorPeriods.length > 0) {
-        setSelectedInstructorPeriodLabel(instructorPeriods[0].label);
-      }
-      if (instructorPeriods.length > 0 && instructorPeriods[0].groupInstructions.length === 1) {
-        setExpandedInstructorGroups(new Set([instructorPeriods[0].groupInstructions[0].groupId]));
+      // 期を降順ソート（最新が先頭）
+      periods.sort((a, b) => b.sortKey - a.sortKey);
+
+      setUnifiedPeriods(periods);
+
+      // デフォルトで最新の期を選択
+      if (periods.length > 0) {
+        setSelectedPeriodLabel(periods[0].label);
       }
 
       setLoading(false);
@@ -260,21 +247,8 @@ export function MemberDetailPage() {
     });
   };
 
-  const toggleInstructorGroup = (groupId) => {
-    setExpandedInstructorGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(groupId)) {
-        next.delete(groupId);
-      } else {
-        next.add(groupId);
-      }
-      return next;
-    });
-  };
-
-  const selectedPeriod = periodAttendances.find((p) => p.label === selectedPeriodLabel);
-  const selectedInstructorPeriod = instructorHistory.find((p) => p.label === selectedInstructorPeriodLabel);
-  const totalInstructorSessions = instructorHistory.reduce((sum, p) => sum + p.totalSessions, 0);
+  const selectedPeriod = unifiedPeriods.find((p) => p.label === selectedPeriodLabel);
+  const totalInstructorSessions = unifiedPeriods.reduce((sum, p) => sum + p.totalInstructorSessions, 0);
 
   if (loading) {
     return (
@@ -355,11 +329,11 @@ export function MemberDetailPage() {
         </div>
       </div>
 
-      {/* 期別2カラムレイアウト */}
-      <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-6" data-section="attendance">
-        {/* 左列: 期サマリーリスト */}
+      {/* 期別2カラムレイアウト（出席履歴 + 講師履歴 統合） */}
+      <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-6">
+        {/* 左列: 統合期サマリーリスト */}
         <div className="space-y-2">
-          {periodAttendances.map((period) => {
+          {unifiedPeriods.map((period) => {
             const isSelected = period.label === selectedPeriodLabel;
             return (
               <button
@@ -374,149 +348,37 @@ export function MemberDetailPage() {
               >
                 <div className="text-base font-bold text-text-primary">{period.label}</div>
                 <div className="flex items-center gap-3 mt-1 text-sm text-text-secondary">
-                  <span className="flex items-center gap-1">
-                    <Calendar className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
-                    <span className="font-display font-semibold">{period.totalSessions}</span>回
-                  </span>
-                  <span className="flex items-center gap-1">
-                    <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
-                    <span className="font-display">{formatDuration(period.totalDurationSeconds)}</span>
-                  </span>
+                  {period.totalSessions > 0 && (
+                    <>
+                      <span className="flex items-center gap-1">
+                        <Calendar className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
+                        <span className="font-display font-semibold">{period.totalSessions}</span>回
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
+                        <span className="font-display">{formatDuration(period.totalDurationSeconds)}</span>
+                      </span>
+                    </>
+                  )}
+                  {period.totalInstructorSessions > 0 && (
+                    <span className="flex items-center gap-1">
+                      <GraduationCap className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
+                      講師 <span className="font-display font-semibold">{period.totalInstructorSessions}</span>回
+                    </span>
+                  )}
                 </div>
               </button>
             );
           })}
         </div>
 
-        {/* 右列: 選択した期のグループ別アコーディオン */}
+        {/* 右列: 選択した期の出席 + 講師グループ別アコーディオン */}
         <div className="space-y-4">
-          {selectedPeriod && selectedPeriod.groupAttendances.map((group, index) => {
-            const isExpanded = expandedGroups.has(group.groupId);
-            return (
-              <div
-                key={group.groupId}
-                className="card-base overflow-hidden animate-fade-in-up"
-                style={{ animationDelay: `${index * 80}ms` }}
-              >
-                {/* サマリーカード */}
-                <button
-                  onClick={() => toggleGroup(group.groupId)}
-                  aria-expanded={isExpanded}
-                  className="w-full px-6 py-3.5 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
-                >
-                  <div className="flex items-center gap-4">
-                    {isExpanded ? (
-                      <ChevronDown className="w-5 h-5 text-text-muted" aria-hidden="true" />
-                    ) : (
-                      <ChevronRight className="w-5 h-5 text-text-muted" aria-hidden="true" />
-                    )}
-                    <div>
-                      <h3 className="text-base font-bold text-text-primary">{group.groupName}</h3>
-                      <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
-                        <span className="flex items-center gap-1.5">
-                          <Calendar className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
-                          <span className="font-display font-semibold text-text-primary">{group.sessionCount}</span>回参加
-                        </span>
-                        <span className="flex items-center gap-1.5">
-                          <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
-                          <span className="font-display">{formatDuration(group.totalDurationSeconds)}</span>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </button>
-
-                {/* 出席履歴テーブル（スムーズアコーディオン展開） */}
-                <div
-                  className="accordion-panel"
-                  data-expanded={isExpanded}
-                  aria-hidden={!isExpanded}
-                >
-                  <div className="accordion-panel-inner">
-                    <div className="border-t border-border-light">
-                      <div className="overflow-x-auto">
-                        <table className="w-full">
-                          <thead>
-                            <tr>
-                              <th scope="col" className="sr-only">
-                                日付
-                              </th>
-                              <th scope="col" className="sr-only">
-                                参加時間
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody className="divide-y divide-border-light">
-                            {group.sessions.map((session) => {
-                              const parts = formatSessionParts(session);
-                              return (
-                                <tr
-                                  key={session.sessionId}
-                                  className="text-sm hover:bg-surface-muted transition-colors"
-                                >
-                                  <td className="px-6 py-3">
-                                    <span className="text-text-primary">{parts.date}</span>
-                                    {parts.title && (
-                                      <span className="ml-2 text-text-secondary">{parts.title}</span>
-                                    )}
-                                  </td>
-                                  <td className="px-6 py-3 text-text-primary text-right font-medium font-display tabular-nums">
-                                    {formatDuration(session.durationSeconds)}
-                                  </td>
-                                </tr>
-                              );
-                            })}
-                          </tbody>
-                        </table>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* 講師履歴セクション — 0件の場合は非表示 */}
-      {instructorHistory.length > 0 && (
-        <>
-          <h3 className="text-lg font-bold text-text-primary flex items-center gap-2">
-            <GraduationCap className="w-5 h-5 text-primary-500" aria-hidden="true" />
-            講師履歴
-          </h3>
-          <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr] gap-6">
-            {/* 左列: 期サマリーリスト */}
-            <div className="space-y-2">
-              {instructorHistory.map((period) => {
-                const isSelected = period.label === selectedInstructorPeriodLabel;
-                return (
-                  <button
-                    key={period.label}
-                    onClick={() => setSelectedInstructorPeriodLabel(period.label)}
-                    aria-pressed={isSelected}
-                    className={`w-full text-left px-4 py-3 rounded-r-lg transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
-                      isSelected
-                        ? 'bg-white shadow-sm border-l-3 border-l-primary-500'
-                        : 'hover:bg-surface-muted border-l-3 border-l-transparent'
-                    }`}
-                  >
-                    <div className="text-base font-bold text-text-primary">{period.label}</div>
-                    <div className="flex items-center gap-3 mt-1 text-sm text-text-secondary">
-                      <span className="flex items-center gap-1">
-                        <GraduationCap className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
-                        <span className="font-display font-semibold">{period.totalSessions}</span>回
-                      </span>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-
-            {/* 右列: 選択した期のグループ別アコーディオン */}
-            <div className="space-y-4">
-              {selectedInstructorPeriod && selectedInstructorPeriod.groupInstructions.map((group, index) => {
-                const isExpanded = expandedInstructorGroups.has(group.groupId);
+          {/* 出席履歴アコーディオン */}
+          {selectedPeriod && selectedPeriod.groupAttendances.length > 0 && (
+            <div className="space-y-4" data-section="attendance">
+              {selectedPeriod.groupAttendances.map((group, index) => {
+                const isExpanded = expandedGroups.has(group.groupId);
                 return (
                   <div
                     key={group.groupId}
@@ -524,7 +386,100 @@ export function MemberDetailPage() {
                     style={{ animationDelay: `${index * 80}ms` }}
                   >
                     <button
-                      onClick={() => toggleInstructorGroup(group.groupId)}
+                      onClick={() => toggleGroup(group.groupId)}
+                      aria-expanded={isExpanded}
+                      className="w-full px-6 py-3.5 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
+                    >
+                      <div className="flex items-center gap-4">
+                        {isExpanded ? (
+                          <ChevronDown className="w-5 h-5 text-text-muted" aria-hidden="true" />
+                        ) : (
+                          <ChevronRight className="w-5 h-5 text-text-muted" aria-hidden="true" />
+                        )}
+                        <div>
+                          <h3 className="text-base font-bold text-text-primary">{group.groupName}</h3>
+                          <div className="flex items-center gap-4 mt-1 text-sm text-text-secondary">
+                            <span className="flex items-center gap-1.5">
+                              <Calendar className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
+                              <span className="font-display font-semibold text-text-primary">{group.sessionCount}</span>回参加
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                              <Clock className="w-3.5 h-3.5 text-text-muted" aria-hidden="true" />
+                              <span className="font-display">{formatDuration(group.totalDurationSeconds)}</span>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </button>
+
+                    <div
+                      className="accordion-panel"
+                      data-expanded={isExpanded}
+                      aria-hidden={!isExpanded}
+                    >
+                      <div className="accordion-panel-inner">
+                        <div className="border-t border-border-light">
+                          <div className="overflow-x-auto">
+                            <table className="w-full">
+                              <thead>
+                                <tr>
+                                  <th scope="col" className="sr-only">
+                                    日付
+                                  </th>
+                                  <th scope="col" className="sr-only">
+                                    参加時間
+                                  </th>
+                                </tr>
+                              </thead>
+                              <tbody className="divide-y divide-border-light">
+                                {group.sessions.map((session) => {
+                                  const parts = formatSessionParts(session);
+                                  return (
+                                    <tr
+                                      key={session.sessionId}
+                                      className="text-sm hover:bg-surface-muted transition-colors"
+                                    >
+                                      <td className="px-6 py-3">
+                                        <span className="text-text-primary">{parts.date}</span>
+                                        {parts.title && (
+                                          <span className="ml-2 text-text-secondary">{parts.title}</span>
+                                        )}
+                                      </td>
+                                      <td className="px-6 py-3 text-text-primary text-right font-medium font-display tabular-nums">
+                                        {formatDuration(session.durationSeconds)}
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* 講師履歴アコーディオン */}
+          {selectedPeriod && selectedPeriod.groupInstructions.length > 0 && (
+            <div className="space-y-4" data-section="instructor">
+              <h3 className="text-base font-bold text-text-primary flex items-center gap-2">
+                <GraduationCap className="w-4 h-4 text-primary-500" aria-hidden="true" />
+                講師履歴
+              </h3>
+              {selectedPeriod.groupInstructions.map((group, index) => {
+                const isExpanded = expandedGroups.has(`instructor-${group.groupId}`);
+                return (
+                  <div
+                    key={`instructor-${group.groupId}`}
+                    className="card-base overflow-hidden animate-fade-in-up"
+                    style={{ animationDelay: `${index * 80}ms` }}
+                  >
+                    <button
+                      onClick={() => toggleGroup(`instructor-${group.groupId}`)}
                       aria-expanded={isExpanded}
                       className="w-full px-6 py-3.5 flex items-center justify-between text-left hover:bg-surface-muted transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
                     >
@@ -589,9 +544,9 @@ export function MemberDetailPage() {
                 );
               })}
             </div>
-          </div>
-        </>
-      )}
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 概要（Why / 目的）

メンバー詳細画面にそのメンバーが講師を務めたセッションの履歴を表示し、講師としての活動を可視化する。

## 変更内容（What）

- **ヘッダーカードに講師回数を追加**: GraduationCap アイコン付きで講師セッション数を表示（0件時は非表示）
- **講師履歴セクションを追加**: 出席履歴セクションの下に、期別・グループ別のアコーディオンレイアウトで講師履歴を表示
- **E2E テストのスコープ修正**: 講師履歴セクション追加により重複した見出し・アコーディオンパネルの問題を解消するため、ロケーターを出席履歴セクションにスコープ限定
- **ユニットテスト追加**: 講師履歴の表示・非表示、期別グルーピング、アコーディオン展開・折りたたみ、期切り替えのテストを追加

## 関連（Issue / チケット / Docs）

- Fixes #163

## 影響範囲・互換性（Impact）

- 破壊的変更: なし
- データ互換（CSV/集計）: 影響なし（既存の `instructors` フィールドを参照するのみ）

## 動作確認・テスト（How verified）

- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み（Lint + Coverage + Build 全通過）
- [x] E2E テスト実行済み（29/31 合格、1件は既知の無関係な不安定テスト）

## スクリーンショット / 画面差分（UI変更がある場合）

メンバー詳細画面に以下が追加されます:
- ヘッダーカード: 「講師 N回」の表示（講師履歴0件時は非表示）
- 講師履歴セクション: 期別2カラムレイアウト（左: 期サマリー、右: グループ別アコーディオン）

## デプロイ / 運用メモ（必要な場合）

- 特になし。静的ホスティングの再デプロイのみで反映されます。

## レビュワーへの補足

- 講師履歴の期別グルーピングは出席履歴と同じパターン（`getFiscalPeriod`）を使用
- E2E テストでは `level: 3`（h3）と `data-section="attendance"` 属性でロケーターをスコープ限定
- MemberDetailPage.jsx の関数カバレッジは100%達成
