### PR TITLE
feat(ci): デプロイ前に古いアセットファイルを削除 (#171)

### DIFF
--- a/.github/workflows/app-deployment.yml
+++ b/.github/workflows/app-deployment.yml
@@ -145,6 +145,14 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: 既存アセットのクリーンアップ
+        run: |
+          az storage blob delete-batch \
+            --source '$web' \
+            --account-name "${{ vars.AZURE_STORAGE_ACCOUNT_NAME }}" \
+            --auth-mode login \
+            --pattern 'assets/*'
+
       - name: Azure Blob Storage に配信
         run: |
           az storage blob upload-batch \


### PR DESCRIPTION
## 概要（Why / 目的）

Vite はビルドごとにコンテンツハッシュ付きのファイル名（例: `assets/index-abc123.js`）を生成する。
現在のデプロイワークフローは `--overwrite` でアップロードしているが、古いハッシュ付きファイルは削除されないため、
`$web` コンテナの `assets/` 配下に不要ファイルが蓄積し続ける問題を解決する。

## 変更内容（What）

- `app-deployment.yml` の deploy ジョブで、アップロードステップの前に `az storage blob delete-batch` で `assets/*` を削除するステップを追加

## 関連（Issue / チケット / Docs）

- Fixes #171

## 影響範囲・互換性（Impact）

- 破壊的変更: なし
- データ互換（CSV/集計）: 影響なし
- `data/` ディレクトリ（ユーザーデータ）は削除対象外
- `index.html` 等ルートファイルはアップロード時の `--overwrite` で上書きされるため削除不要
- アセット削除からアップロード完了まで一瞬のダウンタイムが発生するが、`concurrency` 設定により同時デプロイは防止されており、デプロイ自体が短時間で完了するため許容範囲

## 動作確認・テスト（How verified）

- [x] ビルド確認済み
- [x] pnpm run preflight を実行済み

## スクリーンショット / 画面差分（UI変更がある場合）

UI 変更なし

## デプロイ / 運用メモ（必要な場合）

- dev 環境へのデプロイで `az storage blob delete-batch` が正常実行されることを確認予定
- E2E テストが通ることで必要なアセットが正しくアップロードされていることを検証

## レビュワーへの補足

- ワークフロー YAML の 1 ステップ追加のみの最小変更
