### PR TITLE
test: 講師・主催者機能の E2E テストを追加

### DIFF
--- a/e2e/admin-dev-mode.spec.js
+++ b/e2e/admin-dev-mode.spec.js
@@ -4,170 +4,251 @@ import { restoreIndexJson } from './helpers/fixture-lifecycle.js';
 import { navigateTo } from './helpers/navigation.js';
 
 test.describe('開発モード — ダミートークンでの管理者機能', () => {
-  // データ変更テストは並列実行から分離してシーケンシャルに実行
-  test.describe.configure({ mode: 'serial' });
+    // データ変更テストは並列実行から分離してシーケンシャルに実行
+    test.describe.configure({ mode: 'serial' });
 
-  // データ変更テスト後に即座にバックアップから復元
-  // eslint-disable-next-line no-empty-pattern
-  test.afterEach(async ({}, testInfo) => {
-    if (
-      testInfo.title.includes('グループ名の編集ができること') ||
-      testInfo.title.includes('セッション削除')
-    ) {
-      await restoreIndexJson();
-    }
-  });
-
-  test('token=devで管理者リンクが表示されること', async ({ page }) => {
-    await navigateTo(page, '/?token=dev');
-
-    // ヘッダー表示を待機
-    await expect(page.locator('header')).toContainText('Teams Board');
-
-    // 「管理」リンクが表示されること
-    await expect(page.getByRole('link', { name: '管理' })).toBeVisible();
-  });
-
-  test('token=devで管理者パネルにアクセスできること', async ({ page }) => {
-    await navigateTo(page, '/?token=dev#/admin');
-
-    // 管理者パネルの見出しが表示されること（画面準備完了を確認）
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
-
-    // ドロップゾーンが表示されること
-    await expect(page.getByText('Teams出席レポートCSV')).toBeVisible();
-
-    // グループ・セッション管理セクションが表示されること
-    await expect(page.getByRole('heading', { name: 'グループ・セッション管理' })).toBeVisible();
-  });
-
-  test('token=devでグループ一覧が表示されること', async ({ page }) => {
-    await navigateTo(page, '/?token=dev#/admin');
-
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
-
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
-
-    // グループが表示されること（dev-fixturesのデータを想定）
-    await expect(page.getByText('フロントエンド勉強会').first()).toBeVisible();
-    await expect(page.getByText('TypeScript読書会').first()).toBeVisible();
-  });
-
-  test('token=devでグループ名の編集ができること', async ({ page }) => {
-    await navigateTo(page, '/?token=dev#/admin');
-
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
-
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
-
-    // 最初の編集ボタンをクリック
-    const editButtons = page.getByTitle('グループ名を編集');
-    await editButtons.first().click();
-
-    // 入力フィールドが表示されることを確認
-    const input = page.locator('input[type="text"]').first();
-    await expect(input).toBeVisible();
-    await expect(input).toBeFocused();
-
-    // グループ名を変更
-    const newGroupName = `テストグループ_${Date.now()}`;
-    await input.clear();
-    await input.fill(newGroupName);
-
-    // 保存ボタンをクリック
-    await page.getByTitle('保存').first().click();
-
-    // 新しいグループ名が表示されること
-    await expect(page.getByText(newGroupName)).toBeVisible();
-
-    // コンソールに開発モードのログが出力されることを確認
-    // 注: この検証は、開発サーバーのログで確認する必要があります
-  });
-
-  test('token=devでCSVファイルをアップロードできること', async ({ page }) => {
-    await navigateTo(page, '/?token=dev#/admin');
-
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
-
-    // ファイル入力を取得
-    const fileInput = page.locator('input[type="file"]');
-    await expect(fileInput).toBeAttached();
-
-    // テスト用のCSVファイルパスを指定（実際のファイルパスに置き換える必要があります）
-    // 注: このテストは、実際のCSVファイルが存在する場合にのみ動作します
-    // 実装時には、tests/fixtures/ 配下のCSVファイルを使用してください
-
-    // ここでは、ファイル入力が存在することを確認するにとどめます
-    await expect(fileInput).toBeEnabled();
-  });
-
-  test('開発モードのコンソールメッセージが表示されること', async ({ page }) => {
-    const consoleMessages = [];
-
-    // コンソールメッセージをキャプチャ
-    page.on('console', (msg) => {
-      consoleMessages.push({
-        type: msg.type(),
-        text: msg.text(),
-      });
+    // データ変更テスト後に即座にバックアップから復元
+    // eslint-disable-next-line no-empty-pattern
+    test.afterEach(async ({}, testInfo) => {
+        if (
+            testInfo.title.includes('グループ名の編集ができること') ||
+            testInfo.title.includes('セッション削除') ||
+            testInfo.title.includes('講師を変更して保存') ||
+            testInfo.title.includes('主催者を設定して保存')
+        ) {
+            await restoreIndexJson();
+        }
     });
 
-    await navigateTo(page, '/?token=dev');
+    test('token=devで管理者リンクが表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev');
 
-    // ダッシュボード見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
+        // ヘッダー表示を待機
+        await expect(page.locator('header')).toContainText('Teams Board');
 
-    // 開発モードのログメッセージが出力されていることを確認
-    const devModeMessage = consoleMessages.find(
-      (msg) => msg.text.includes('開発モード') && msg.text.includes('ダミートークン')
-    );
+        // 「管理」リンクが表示されること
+        await expect(page.getByRole('link', { name: '管理' })).toBeVisible();
+    });
 
-    expect(devModeMessage).toBeDefined();
-    expect(devModeMessage?.type).toBe('info');
-  });
+    test('token=devで管理者パネルにアクセスできること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev#/admin');
 
-  test('token=devでグループ詳細画面からセッション削除ができること', async ({ page }) => {
-    // グループ詳細画面にアクセス（フロントエンド勉強会）
-    await navigateTo(page, '/?token=dev#/groups/01KHNHF98M86MWSATH6W4TR205');
+        // 管理者パネルの見出しが表示されること（画面準備完了を確認）
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ名の表示を待機
-    await expect(page.getByText('フロントエンド勉強会').first()).toBeVisible();
+        // ドロップゾーンが表示されること
+        await expect(page.getByText('Teams出席レポートCSV')).toBeVisible();
 
-    // 削除ボタンが表示されること
-    const deleteButtons = page.getByRole('button', { name: /のセッションを削除/ });
-    await expect(deleteButtons.first()).toBeVisible();
+        // グループ・セッション管理セクションが表示されること
+        await expect(page.getByRole('heading', { name: 'グループ・セッション管理' })).toBeVisible();
+    });
 
-    // 最初の削除ボタンをクリック
-    await deleteButtons.first().click();
+    test('token=devでグループ一覧が表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev#/admin');
 
-    // 確認ダイアログが表示されること
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible();
-    await expect(dialog.getByText('セッションの削除')).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // 削除実行
-    await dialog.getByRole('button', { name: '削除' }).click();
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // 成功メッセージが表示されること
-    await expect(page.getByText('セッションを削除しました')).toBeVisible();
-  });
+        // グループが表示されること（dev-fixturesのデータを想定）
+        await expect(page.getByText('フロントエンド勉強会').first()).toBeVisible();
+        await expect(page.getByText('TypeScript読書会').first()).toBeVisible();
+    });
 
-  test('URLからtoken=devが削除されること', async ({ page }) => {
-    await navigateTo(page, '/?token=dev');
+    test('token=devでグループ名の編集ができること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev#/admin');
 
-    // ダッシュボード見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // URLにtokenパラメータが含まれていないことを確認
-    const url = new URL(page.url());
-    expect(url.searchParams.has('token')).toBe(false);
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // しかし、管理者リンクは表示されること（トークンはメモリに保持されている）
-    await expect(page.getByRole('link', { name: '管理' })).toBeVisible();
-  });
+        // 最初の編集ボタンをクリック
+        const editButtons = page.getByTitle('グループ名を編集');
+        await editButtons.first().click();
+
+        // 入力フィールドが表示されることを確認
+        const input = page.locator('input[type="text"]').first();
+        await expect(input).toBeVisible();
+        await expect(input).toBeFocused();
+
+        // グループ名を変更
+        const newGroupName = `テストグループ_${Date.now()}`;
+        await input.clear();
+        await input.fill(newGroupName);
+
+        // 保存ボタンをクリック
+        await page.getByTitle('保存').first().click();
+
+        // 新しいグループ名が表示されること
+        await expect(page.getByText(newGroupName)).toBeVisible();
+
+        // コンソールに開発モードのログが出力されることを確認
+        // 注: この検証は、開発サーバーのログで確認する必要があります
+    });
+
+    test('token=devでCSVファイルをアップロードできること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev#/admin');
+
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+
+        // ファイル入力を取得
+        const fileInput = page.locator('input[type="file"]');
+        await expect(fileInput).toBeAttached();
+
+        // テスト用のCSVファイルパスを指定（実際のファイルパスに置き換える必要があります）
+        // 注: このテストは、実際のCSVファイルが存在する場合にのみ動作します
+        // 実装時には、tests/fixtures/ 配下のCSVファイルを使用してください
+
+        // ここでは、ファイル入力が存在することを確認するにとどめます
+        await expect(fileInput).toBeEnabled();
+    });
+
+    test('開発モードのコンソールメッセージが表示されること', async ({ page }) => {
+        const consoleMessages = [];
+
+        // コンソールメッセージをキャプチャ
+        page.on('console', (msg) => {
+            consoleMessages.push({
+                type: msg.type(),
+                text: msg.text(),
+            });
+        });
+
+        await navigateTo(page, '/?token=dev');
+
+        // ダッシュボード見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
+
+        // 開発モードのログメッセージが出力されていることを確認
+        const devModeMessage = consoleMessages.find(
+            (msg) => msg.text.includes('開発モード') && msg.text.includes('ダミートークン')
+        );
+
+        expect(devModeMessage).toBeDefined();
+        expect(devModeMessage?.type).toBe('info');
+    });
+
+    test('token=devでグループに主催者を設定して保存できること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev#/admin');
+
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
+
+        // 主催者未設定のグループ（「ソフトウェア設計勉強会」）を展開
+        await page.getByRole('button', { name: /ソフトウェア設計勉強会 を展開/ }).click();
+
+        // 主催者検索入力にフォーカスしてドロップダウンを開く
+        const organizerInput = page.getByRole('combobox', { name: '主催者を検索' }).first();
+        await organizerInput.scrollIntoViewIfNeeded();
+        await expect(organizerInput).toBeVisible();
+        await organizerInput.focus();
+
+        // ドロップダウンから既存候補を選択
+        const listbox = page.getByRole('listbox', { name: '主催者候補' });
+        await expect(listbox).toBeVisible();
+        await listbox.getByRole('option').first().click();
+
+        // 主催者を保存ボタンをクリック（レイアウト重なりのためDOMクリックを使用）
+        const saveOrganizerButton = page.getByRole('button', { name: /主催者を保存/ }).first();
+        await saveOrganizerButton.evaluate((el) => el.click());
+
+        // 成功メッセージを確認
+        await expect(page.getByText('主催者を保存しました')).toBeVisible();
+    });
+
+    test('token=devでセッションの講師を変更して保存できること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev#/admin');
+
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
+
+        // グループ（「フロントエンド勉強会」）を展開
+        await page.getByRole('button', { name: /フロントエンド勉強会 を展開/ }).click();
+
+        // セッション行をクリックして右側の SessionEditorPanel を表示
+        // セッション一覧の最初のセッション（日付ボタン）をクリック
+        const sessionButtons = page.locator('button:has(.tabular-nums.text-text-muted.text-xs)');
+        await sessionButtons.first().scrollIntoViewIfNeeded();
+        await expect(sessionButtons.first()).toBeVisible();
+        await sessionButtons.first().click({ force: true });
+
+        // SessionEditorPanel が表示されること（セッション名ラベルで確認）
+        await expect(page.getByLabel(/のセッション名/)).toBeVisible();
+
+        // 講師セクションの検索入力にフォーカスしてドロップダウンを開く
+        const instructorInput = page.getByRole('combobox', { name: '講師を検索' });
+        await instructorInput.scrollIntoViewIfNeeded();
+        await expect(instructorInput).toBeVisible();
+        await instructorInput.focus();
+
+        // ドロップダウンから候補を選択
+        const instructorListbox = page.getByRole('listbox', { name: '講師候補' });
+        await expect(instructorListbox).toBeVisible();
+        await instructorListbox.getByRole('option').first().click();
+
+        // 保存ボタンをクリック（SessionEditorPanel の保存ボタン）
+        await page.getByRole('button', { name: '保存', exact: true }).click();
+
+        // 成功メッセージを確認
+        await expect(page.getByText('セッションを保存しました')).toBeVisible();
+    });
+
+    test('token=devでグループ詳細画面からセッション削除ができること', async ({ page }) => {
+        // グループ詳細画面にアクセス（フロントエンド勉強会）
+        await navigateTo(page, '/?token=dev#/groups/01KHNHF98M86MWSATH6W4TR205');
+
+        // グループ名の表示を待機
+        await expect(page.getByText('フロントエンド勉強会').first()).toBeVisible();
+
+        // 削除ボタンが表示されること
+        const deleteButtons = page.getByRole('button', { name: /のセッションを削除/ });
+        await expect(deleteButtons.first()).toBeVisible();
+
+        // 最初の削除ボタンをクリック
+        await deleteButtons.first().click();
+
+        // 確認ダイアログが表示されること
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible();
+        await expect(dialog.getByText('セッションの削除')).toBeVisible();
+
+        // 削除実行
+        await dialog.getByRole('button', { name: '削除' }).click();
+
+        // 成功メッセージが表示されること
+        await expect(page.getByText('セッションを削除しました')).toBeVisible();
+    });
+
+    test('URLからtoken=devが削除されること', async ({ page }) => {
+        await navigateTo(page, '/?token=dev');
+
+        // ダッシュボード見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
+
+        // URLにtokenパラメータが含まれていないことを確認
+        const url = new URL(page.url());
+        expect(url.searchParams.has('token')).toBe(false);
+
+        // しかし、管理者リンクは表示されること（トークンはメモリに保持されている）
+        await expect(page.getByRole('link', { name: '管理' })).toBeVisible();
+    });
 });

--- a/e2e/admin-group-edit.spec.js
+++ b/e2e/admin-group-edit.spec.js
@@ -6,151 +6,187 @@ import { navigateTo } from './helpers/navigation.js';
 const fetchIndex = async () => getIndexFixture();
 
 test.beforeEach(async ({ page }) => {
-  await registerIndexRoute(page);
+    await registerIndexRoute(page);
 });
 
 test.describe('管理者パネル — グループ名編集', () => {
-  test('グループ管理セクションが表示されること', async ({ page }) => {
-    await navigateTo(page, '/?token=test-sas-token#/admin');
+    test('グループ管理セクションが表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
 
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ・セッション管理セクションの見出しが表示されること
-    await expect(page.getByRole('heading', { name: 'グループ・セッション管理' })).toBeVisible();
+        // グループ・セッション管理セクションの見出しが表示されること
+        await expect(page.getByRole('heading', { name: 'グループ・セッション管理' })).toBeVisible();
 
-    // 説明文が表示されること
-    await expect(
-      page.getByText('グループの編集・統合と、セッション名の管理ができます')
-    ).toBeVisible();
-  });
+        // 説明文が表示されること
+        await expect(
+            page.getByText('グループの編集・統合と、セッション名の管理ができます')
+        ).toBeVisible();
+    });
 
-  test('グループ一覧が表示されること', async ({ page }) => {
-    await navigateTo(page, '/?token=test-sas-token#/admin');
+    test('グループ一覧が表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
 
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // グループ名が表示されていること
-    const index = await fetchIndex();
-    const groupNames = index.groups.map((group) => group.name).slice(0, 2);
-    for (const name of groupNames) {
-      await expect(page.getByText(name).first()).toBeVisible();
-    }
-  });
+        // グループ名が表示されていること
+        const index = await fetchIndex();
+        const groupNames = index.groups.map((group) => group.name).slice(0, 2);
+        for (const name of groupNames) {
+            await expect(page.getByText(name).first()).toBeVisible();
+        }
+    });
 
-  test('グループ名の編集ボタンが表示されること', async ({ page }) => {
-    await navigateTo(page, '/?token=test-sas-token#/admin');
+    test('グループ名の編集ボタンが表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
 
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // 編集ボタンが存在すること（少なくとも1つ）
-    const editButtons = page.getByTitle('グループ名を編集');
-    await expect(editButtons.first()).toBeVisible();
-  });
+        // 編集ボタンが存在すること（少なくとも1つ）
+        const editButtons = page.getByTitle('グループ名を編集');
+        await expect(editButtons.first()).toBeVisible();
+    });
 
-  test('編集ボタンをクリックすると入力フィールドが表示されること', async ({ page }) => {
-    await navigateTo(page, '/?token=test-sas-token#/admin');
+    test('編集ボタンをクリックすると入力フィールドが表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
 
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // 最初の編集ボタンをクリック
-    const editButtons = page.getByTitle('グループ名を編集');
-    await editButtons.first().click();
+        // 最初の編集ボタンをクリック
+        const editButtons = page.getByTitle('グループ名を編集');
+        await editButtons.first().click();
 
-    // 入力フィールドが表示されること
-    const input = page.getByPlaceholder('グループ名を入力');
-    await expect(input).toBeVisible();
-    await expect(input).toBeFocused();
+        // 入力フィールドが表示されること
+        const input = page.getByPlaceholder('グループ名を入力');
+        await expect(input).toBeVisible();
+        await expect(input).toBeFocused();
 
-    // 保存とキャンセルボタンが表示されること
-    await expect(page.getByTitle('保存').first()).toBeVisible();
-    await expect(page.getByTitle('キャンセル').first()).toBeVisible();
-  });
+        // 保存とキャンセルボタンが表示されること
+        await expect(page.getByTitle('保存').first()).toBeVisible();
+        await expect(page.getByTitle('キャンセル').first()).toBeVisible();
+    });
 
-  test('キャンセルボタンをクリックすると編集モードが解除されること', async ({ page }) => {
-    await navigateTo(page, '/?token=test-sas-token#/admin');
+    test('キャンセルボタンをクリックすると編集モードが解除されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
 
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // 編集ボタンをクリック
-    const editButtons = page.getByTitle('グループ名を編集');
-    await editButtons.first().click();
+        // 編集ボタンをクリック
+        const editButtons = page.getByTitle('グループ名を編集');
+        await editButtons.first().click();
 
-    // 入力フィールドが表示されることを確認
-    const input = page.getByPlaceholder('グループ名を入力');
-    await expect(input).toBeVisible();
+        // 入力フィールドが表示されることを確認
+        const input = page.getByPlaceholder('グループ名を入力');
+        await expect(input).toBeVisible();
 
-    // キャンセルボタンをクリック
-    await page.getByTitle('キャンセル').first().click();
+        // キャンセルボタンをクリック
+        await page.getByTitle('キャンセル').first().click();
 
-    // 入力フィールドが非表示になること
-    await expect(input).not.toBeVisible();
-  });
+        // 入力フィールドが非表示になること
+        await expect(input).not.toBeVisible();
+    });
 
-  test('Escapeキーで編集モードが解除されること', async ({ page }) => {
-    await navigateTo(page, '/?token=test-sas-token#/admin');
+    test('Escapeキーで編集モードが解除されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
 
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // 編集ボタンをクリック
-    const editButtons = page.getByTitle('グループ名を編集');
-    await editButtons.first().click();
+        // 編集ボタンをクリック
+        const editButtons = page.getByTitle('グループ名を編集');
+        await editButtons.first().click();
 
-    // 入力フィールドが表示されることを確認
-    const input = page.getByPlaceholder('グループ名を入力');
-    await expect(input).toBeVisible();
+        // 入力フィールドが表示されることを確認
+        const input = page.getByPlaceholder('グループ名を入力');
+        await expect(input).toBeVisible();
 
-    // Escapeキーを押す
-    await input.press('Escape');
+        // Escapeキーを押す
+        await input.press('Escape');
 
-    // 入力フィールドが非表示になること
-    await expect(input).not.toBeVisible();
-  });
+        // 入力フィールドが非表示になること
+        await expect(input).not.toBeVisible();
+    });
 
-  test('空文字での保存を試みるとエラーメッセージが表示されること', async ({ page }) => {
-    await navigateTo(page, '/?token=test-sas-token#/admin');
+    test('グループを展開すると主催者セクションが表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
 
-    // 管理者パネル見出しで画面準備完了を確認
-    await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
 
-    // グループ・セッション管理セクションまでスクロール
-    await page.getByRole('heading', { name: 'グループ・セッション管理' }).scrollIntoViewIfNeeded();
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
 
-    // 編集ボタンをクリック
-    const editButtons = page.getByTitle('グループ名を編集');
-    await editButtons.first().click();
+        // フロントエンド勉強会のアコーディオンを展開
+        await page.getByRole('button', { name: /フロントエンド勉強会 を展開/ }).click();
 
-    // 入力フィールドをクリアして空にする
-    const input = page.getByPlaceholder('グループ名を入力');
-    await input.clear();
+        // 主催者ラベルテキストが表示されること
+        await expect(page.getByText('主催者').first()).toBeVisible();
 
-    // 保存ボタンをクリック
-    await page.getByTitle('保存').first().click();
+        // 主催者検索入力が表示されること
+        await expect(page.getByPlaceholder('主催者を検索または新規追加...').first()).toBeVisible();
 
-    // エラーメッセージが表示されること
-    await expect(page.getByText('グループ名を入力してください')).toBeVisible();
+        // 主催者を保存ボタンが表示されること
+        await expect(page.getByText('主催者を保存').first()).toBeVisible();
+    });
 
-    // 編集モードが継続されること
-    await expect(input).toBeVisible();
-  });
+    test('空文字での保存を試みるとエラーメッセージが表示されること', async ({ page }) => {
+        await navigateTo(page, '/?token=test-sas-token#/admin');
+
+        // 管理者パネル見出しで画面準備完了を確認
+        await expect(page.getByRole('heading', { name: '管理者パネル' })).toBeVisible();
+
+        // グループ・セッション管理セクションまでスクロール
+        await page
+            .getByRole('heading', { name: 'グループ・セッション管理' })
+            .scrollIntoViewIfNeeded();
+
+        // 編集ボタンをクリック
+        const editButtons = page.getByTitle('グループ名を編集');
+        await editButtons.first().click();
+
+        // 入力フィールドをクリアして空にする
+        const input = page.getByPlaceholder('グループ名を入力');
+        await input.clear();
+
+        // 保存ボタンをクリック
+        await page.getByTitle('保存').first().click();
+
+        // エラーメッセージが表示されること
+        await expect(page.getByText('グループ名を入力してください')).toBeVisible();
+
+        // 編集モードが継続されること
+        await expect(input).toBeVisible();
+    });
 });

--- a/e2e/dashboard.spec.js
+++ b/e2e/dashboard.spec.js
@@ -6,292 +6,456 @@ import { navigateTo } from './helpers/navigation.js';
 const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const getMemberGroups = (index, member) =>
-  index.groups.filter((group) => group.sessionRevisions.some((ref) => member.sessionRevisions.includes(ref)));
+    index.groups.filter((group) =>
+        group.sessionRevisions.some((ref) => member.sessionRevisions.includes(ref))
+    );
 
 const selectMember = (index, minGroups) =>
-  index.members.find((member) => getMemberGroups(index, member).length >= minGroups) ??
-  index.members[0];
+    index.members.find((member) => getMemberGroups(index, member).length >= minGroups) ??
+    index.members[0];
 
 const selectGroup = (index) => index.groups[0];
 
 const fetchIndex = async () => getIndexFixture();
 
 test.beforeEach(async ({ page }) => {
-  await registerIndexRoute(page);
+    await registerIndexRoute(page);
 });
 
 test.describe('ダッシュボード画面', () => {
-  test('グループ一覧が表示されること', async ({ page }) => {
-    await navigateTo(page, '/');
+    test('グループ一覧が表示されること', async ({ page }) => {
+        await navigateTo(page, '/');
 
-    // ヘッダーが表示されること（画面準備完了を確認）
-    await expect(page.locator('header')).toContainText('Teams Board');
+        // ヘッダーが表示されること（画面準備完了を確認）
+        await expect(page.locator('header')).toContainText('Teams Board');
 
-    // グループセクションが表示されること
-    await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
+        // グループセクションが表示されること
+        await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
 
-    // グループが存在すること
-    const index = await fetchIndex();
-    const groupNames = index.groups.map((group) => group.name).slice(0, 4);
-    for (const name of groupNames) {
-      await expect(page.getByText(name).first()).toBeVisible();
-    }
-  });
+        // グループが存在すること
+        const index = await fetchIndex();
+        const groupNames = index.groups.map((group) => group.name).slice(0, 4);
+        for (const name of groupNames) {
+            await expect(page.getByText(name).first()).toBeVisible();
+        }
+    });
 
-  test('メンバー一覧が表示されること', async ({ page }) => {
-    await navigateTo(page, '/');
+    test('メンバー一覧が表示されること', async ({ page }) => {
+        await navigateTo(page, '/');
 
-    // ヘッダー表示で画面準備完了を確認
-    await expect(page.locator('header')).toContainText('Teams Board');
+        // ヘッダー表示で画面準備完了を確認
+        await expect(page.locator('header')).toContainText('Teams Board');
 
-    // メンバーセクションが表示されること
-    await expect(page.getByRole('heading', { name: 'メンバー' })).toBeVisible();
+        // メンバーセクションが表示されること
+        await expect(page.getByRole('heading', { name: 'メンバー' })).toBeVisible();
 
-    // メンバーが存在すること
-    const index = await fetchIndex();
-    const memberRows = page.getByTestId('member-row');
-    await expect(memberRows).toHaveCount(index.members.length);
-  });
+        // メンバーが存在すること
+        const index = await fetchIndex();
+        const memberRows = page.getByTestId('member-row');
+        await expect(memberRows).toHaveCount(index.members.length);
+    });
+
+    test('グループ一覧に主催者名が表示されること', async ({ page }) => {
+        await navigateTo(page, '/');
+
+        // ヘッダー表示で画面準備完了を確認
+        await expect(page.locator('header')).toContainText('Teams Board');
+
+        const index = await fetchIndex();
+        const organizerMap = new Map((index.organizers ?? []).map((o) => [o.id, o.name]));
+
+        // organizerId が設定されたグループ行に主催者名が表示されること
+        for (const group of index.groups) {
+            if (!group.organizerId) continue;
+            const organizerName = organizerMap.get(group.organizerId);
+            if (!organizerName) continue;
+            const groupRow = page.getByTestId('group-row').filter({ hasText: group.name });
+            await expect(groupRow.getByText(organizerName)).toBeVisible();
+        }
+    });
+
+    test('メンバー一覧に講師回数が表示されること', async ({ page }) => {
+        await navigateTo(page, '/');
+
+        // ヘッダー表示で画面準備完了を確認
+        await expect(page.locator('header')).toContainText('Teams Board');
+
+        const index = await fetchIndex();
+
+        // instructorCount > 0 のメンバー行に講師回数バッジが表示されること
+        for (const member of index.members) {
+            if (!member.instructorCount || member.instructorCount <= 0) continue;
+            const memberRow = page.getByTestId('member-row').filter({ hasText: member.name });
+            // 講師回数バッジ（bg-primary-50 クラス）内に回数が表示されること
+            const badge = memberRow.locator('.bg-primary-50');
+            await expect(badge).toBeVisible();
+            await expect(badge).toContainText(`${member.instructorCount}`);
+            await expect(badge).toContainText('回');
+        }
+    });
 });
 
 test.describe('画面遷移', () => {
-  test('メンバーをクリックして詳細画面に遷移できること', async ({ page }) => {
-    await navigateTo(page, '/');
+    test('メンバーをクリックして詳細画面に遷移できること', async ({ page }) => {
+        await navigateTo(page, '/');
 
-    // ヘッダー表示で画面準備完了を確認
-    await expect(page.locator('header')).toContainText('Teams Board');
+        // ヘッダー表示で画面準備完了を確認
+        await expect(page.locator('header')).toContainText('Teams Board');
 
-    // メンバー行が表示されるまで待つ
-    const memberRow = page.getByTestId('member-row').first();
-    await expect(memberRow).toBeVisible();
+        // メンバー行が表示されるまで待つ
+        const memberRow = page.getByTestId('member-row').first();
+        await expect(memberRow).toBeVisible();
 
-    // メンバー名を取得
-    const memberName = await memberRow.locator('h3').textContent();
+        // メンバー名を取得
+        const memberName = await memberRow.locator('h3').textContent();
 
-    // クリック
-    await memberRow.click();
+        // クリック
+        await memberRow.click();
 
-    // 詳細画面に遷移 — メンバー名がヘッダーに表示される
-    await expect(page.getByRole('heading', { name: memberName })).toBeVisible();
+        // 詳細画面に遷移 — メンバー名がヘッダーに表示される
+        await expect(page.getByRole('heading', { name: memberName })).toBeVisible();
 
-    // 「一覧へ戻る」ボタンが表示されること
-    await expect(page.getByText('一覧へ戻る')).toBeVisible();
-  });
+        // 「一覧へ戻る」ボタンが表示されること
+        await expect(page.getByText('一覧へ戻る')).toBeVisible();
+    });
 
-  test('「一覧へ戻る」ボタンでダッシュボードに戻れること', async ({ page }) => {
-    await navigateTo(page, '/');
+    test('「一覧へ戻る」ボタンでダッシュボードに戻れること', async ({ page }) => {
+        await navigateTo(page, '/');
 
-    // ヘッダー表示で画面準備完了を確認
-    await expect(page.locator('header')).toContainText('Teams Board');
+        // ヘッダー表示で画面準備完了を確認
+        await expect(page.locator('header')).toContainText('Teams Board');
 
-    // メンバー行をクリック
-    const memberRow = page.getByTestId('member-row').first();
-    await expect(memberRow).toBeVisible();
-    await memberRow.click();
+        // メンバー行をクリック
+        const memberRow = page.getByTestId('member-row').first();
+        await expect(memberRow).toBeVisible();
+        await memberRow.click();
 
-    // 詳細画面が表示されるまで待つ
-    await expect(page.getByText('一覧へ戻る')).toBeVisible();
+        // 詳細画面が表示されるまで待つ
+        await expect(page.getByText('一覧へ戻る')).toBeVisible();
 
-    // 「一覧へ戻る」をクリック
-    await page.getByText('一覧へ戻る').click();
+        // 「一覧へ戻る」をクリック
+        await page.getByText('一覧へ戻る').click();
 
-    // ダッシュボードに戻る
-    await expect(page.getByRole('heading', { name: 'メンバー' })).toBeVisible();
-  });
+        // ダッシュボードに戻る
+        await expect(page.getByRole('heading', { name: 'メンバー' })).toBeVisible();
+    });
 
-  test('存在しないルートにアクセスするとダッシュボードにリダイレクトされること', async ({
-    page,
-  }) => {
-    await navigateTo(page, '/#/nonexistent-route');
+    test('存在しないルートにアクセスするとダッシュボードにリダイレクトされること', async ({
+        page,
+    }) => {
+        await navigateTo(page, '/#/nonexistent-route');
 
-    // ダッシュボードが表示されること
-    await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
-  });
+        // ダッシュボードが表示されること
+        await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
+    });
 });
 
 test.describe('グループ詳細画面', () => {
-  test('トップページからグループをクリックして詳細画面に遷移できること', async ({ page }) => {
-    await navigateTo(page, '/');
+    test('トップページからグループをクリックして詳細画面に遷移できること', async ({ page }) => {
+        await navigateTo(page, '/');
 
-    // ヘッダー表示で画面準備完了を確認
-    await expect(page.locator('header')).toContainText('Teams Board');
+        // ヘッダー表示で画面準備完了を確認
+        await expect(page.locator('header')).toContainText('Teams Board');
 
-    // グループ行が表示されるまで待つ
-    const groupRow = page.getByTestId('group-row').first();
-    await expect(groupRow).toBeVisible();
+        // グループ行が表示されるまで待つ
+        const groupRow = page.getByTestId('group-row').first();
+        await expect(groupRow).toBeVisible();
 
-    // グループ名を取得
-    const groupName = await groupRow.locator('h3').textContent();
+        // グループ名を取得
+        const groupName = await groupRow.locator('h3').textContent();
 
-    // クリック
-    await groupRow.click();
+        // クリック
+        await groupRow.click();
 
-    // 詳細画面に遷移 — グループ名がヘッダーに表示される
-    await expect(page.getByRole('heading', { name: groupName })).toBeVisible();
+        // 詳細画面に遷移 — グループ名がヘッダーに表示される
+        await expect(page.getByRole('heading', { name: groupName })).toBeVisible();
 
-    // 「一覧へ戻る」ボタンが表示されること
-    await expect(page.getByText('一覧へ戻る')).toBeVisible();
-  });
+        // 「一覧へ戻る」ボタンが表示されること
+        await expect(page.getByText('一覧へ戻る')).toBeVisible();
+    });
 
-  test('グループ詳細画面でセッション一覧が表示されること', async ({ page }) => {
-    const index = await fetchIndex();
-    const group = selectGroup(index);
-    if (!group) {
-      throw new Error('グループデータが存在しないためテストできません');
-    }
-    await navigateTo(page, `/#/groups/${group.id}`);
+    test('グループ詳細画面でセッション一覧が表示されること', async ({ page }) => {
+        const index = await fetchIndex();
+        const group = selectGroup(index);
+        if (!group) {
+            throw new Error('グループデータが存在しないためテストできません');
+        }
+        await navigateTo(page, `/#/groups/${group.id}`);
 
-    // グループ名が表示される（画面準備完了を確認）
-    await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
+        // グループ名が表示される（画面準備完了を確認）
+        await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
 
-    // 開催回数が表示される
-    await expect(page.getByText(new RegExp(`${group.sessionRevisions.length}回開催`))).toBeVisible();
+        // 開催回数が表示される
+        await expect(
+            page.getByText(new RegExp(`${group.sessionRevisions.length}回開催`))
+        ).toBeVisible();
 
-    // セッション日付が表示される（複数あるので折りたたみ状態）
-    const expandedTables = page.locator('.accordion-panel[data-expanded="true"] table');
-    await expect(expandedTables).toHaveCount(0);
-  });
+        // セッション日付が表示される（複数あるので折りたたみ状態）
+        const expandedTables = page.locator('.accordion-panel[data-expanded="true"] table');
+        await expect(expandedTables).toHaveCount(0);
+    });
 
-  test('セッションをクリックして参加者詳細を展開・折りたたみできること', async ({ page }) => {
-    const index = await fetchIndex();
-    const group = selectGroup(index);
-    if (!group) {
-      throw new Error('グループデータが存在しないためテストできません');
-    }
-    await navigateTo(page, `/#/groups/${group.id}`);
+    test('セッションをクリックして参加者詳細を展開・折りたたみできること', async ({ page }) => {
+        const index = await fetchIndex();
+        const group = selectGroup(index);
+        if (!group) {
+            throw new Error('グループデータが存在しないためテストできません');
+        }
+        await navigateTo(page, `/#/groups/${group.id}`);
 
-    // セッション日付が表示されるまで待つ（画面準備完了を確認）
-    await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
+        // セッション日付が表示されるまで待つ（画面準備完了を確認）
+        await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
 
-    // セッションをクリックして展開
-    const expandedTables = page.locator('.accordion-panel[data-expanded="true"] table');
-    const sessionHeadings = page.getByRole('heading', { level: 3 });
-    await sessionHeadings.first().click();
-    await expect(expandedTables).toHaveCount(1);
+        // セッションをクリックして展開
+        const expandedTables = page.locator('.accordion-panel[data-expanded="true"] table');
+        const sessionHeadings = page.getByRole('heading', { level: 3 });
+        await sessionHeadings.first().click();
+        await expect(expandedTables).toHaveCount(1);
 
-    // テーブルに名前列と参加時間列がある
-    const expandedPanel = page.locator('.accordion-panel[data-expanded="true"]').first();
-    await expect(expandedPanel.getByRole('columnheader', { name: '名前' })).toBeVisible();
-    await expect(expandedPanel.getByRole('columnheader', { name: '参加時間' })).toBeVisible();
+        // テーブルに名前列と参加時間列がある
+        const expandedPanel = page.locator('.accordion-panel[data-expanded="true"]').first();
+        await expect(expandedPanel.getByRole('columnheader', { name: '名前' })).toBeVisible();
+        await expect(expandedPanel.getByRole('columnheader', { name: '参加時間' })).toBeVisible();
 
-    // 再クリックで折りたたみ
-    await sessionHeadings.first().click();
-    await expect(expandedTables).toHaveCount(0);
-  });
+        // 再クリックで折りたたみ
+        await sessionHeadings.first().click();
+        await expect(expandedTables).toHaveCount(0);
+    });
 
-  test('グループ詳細画面から「一覧へ戻る」でダッシュボードに戻れること', async ({ page }) => {
-    const index = await fetchIndex();
-    const group = selectGroup(index);
-    if (!group) {
-      throw new Error('グループデータが存在しないためテストできません');
-    }
-    await navigateTo(page, `/#/groups/${group.id}`);
+    test('グループ詳細画面のヘッダーに主催者名が表示されること', async ({ page }) => {
+        const index = await fetchIndex();
+        // organizerId が設定されたグループ（フロントエンド勉強会）に遷移
+        const group = index.groups.find((g) => g.organizerId);
+        if (!group) {
+            throw new Error('主催者が設定されたグループが存在しないためテストできません');
+        }
+        const organizerMap = new Map((index.organizers ?? []).map((o) => [o.id, o.name]));
+        const organizerName = organizerMap.get(group.organizerId);
+        await navigateTo(page, `/#/groups/${group.id}`);
 
-    // 詳細画面が表示されるまで待つ（画面準備完了を確認）
-    await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
+        // グループ名が表示される（画面準備完了を確認）
+        await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
 
-    // 「一覧へ戻る」をクリック
-    await page.getByText('一覧へ戻る').click();
+        // ヘッダーカード内に主催者名テキストが表示されること
+        await expect(page.getByText(organizerName)).toBeVisible();
+    });
 
-    // ダッシュボードに戻る
-    await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
-  });
+    test('セッション一覧に講師名が表示されること', async ({ page }) => {
+        const index = await fetchIndex();
+        // フロントエンド勉強会（講師データあり）に遷移
+        const group = index.groups.find((g) => g.id === '01KHNHF98M86MWSATH6W4TR205');
+        if (!group) {
+            throw new Error('フロントエンド勉強会が存在しないためテストできません');
+        }
+        await navigateTo(page, `/#/groups/${group.id}`);
+
+        // グループ名が表示される（画面準備完了を確認）
+        await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
+
+        // セッションに講師名が表示されていること（「、」区切り）
+        // 講師名のいずれかがページ内に表示されていることを確認
+        const instructorMembers = index.members.filter((m) => (m.instructorCount ?? 0) > 0);
+        let foundInstructor = false;
+        for (const member of instructorMembers) {
+            const count = await page.getByText(member.name).count();
+            if (count > 0) {
+                foundInstructor = true;
+                break;
+            }
+        }
+        expect(foundInstructor).toBe(true);
+    });
+
+    test('グループ詳細画面から「一覧へ戻る」でダッシュボードに戻れること', async ({ page }) => {
+        const index = await fetchIndex();
+        const group = selectGroup(index);
+        if (!group) {
+            throw new Error('グループデータが存在しないためテストできません');
+        }
+        await navigateTo(page, `/#/groups/${group.id}`);
+
+        // 詳細画面が表示されるまで待つ（画面準備完了を確認）
+        await expect(page.getByRole('heading', { name: group.name })).toBeVisible();
+
+        // 「一覧へ戻る」をクリック
+        await page.getByText('一覧へ戻る').click();
+
+        // ダッシュボードに戻る
+        await expect(page.getByRole('heading', { name: 'グループ', level: 2 })).toBeVisible();
+    });
 });
 
 test.describe('メンバー詳細画面 — グループ別表示', () => {
-  test('複数グループに参加しているメンバーでグループ別サマリーカードが表示されること', async ({
-    page,
-  }) => {
-    const index = await fetchIndex();
-    const member = selectMember(index, 2);
-    const memberGroups = member ? getMemberGroups(index, member) : [];
-    if (!member || memberGroups.length < 2) {
-      throw new Error('複数グループのメンバーが必要です');
-    }
-    await navigateTo(page, `/#/members/${member.id}`);
+    test('複数グループに参加しているメンバーでグループ別サマリーカードが表示されること', async ({
+        page,
+    }) => {
+        const index = await fetchIndex();
+        const member = selectMember(index, 2);
+        const memberGroups = member ? getMemberGroups(index, member) : [];
+        if (!member || memberGroups.length < 2) {
+            throw new Error('複数グループのメンバーが必要です');
+        }
+        await navigateTo(page, `/#/members/${member.id}`);
 
-    // メンバー名が表示される（画面準備完了を確認）
-    await expect(
-      page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
-    ).toBeVisible();
+        // メンバー名が表示される（画面準備完了を確認）
+        await expect(
+            page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
+        ).toBeVisible();
 
-    // グループサマリーカードが表示される
-    for (const group of memberGroups) {
-      await expect(page.getByRole('heading', { name: group.name, level: 3 })).toBeVisible();
-    }
-  });
+        // グループサマリーカードが表示される
+        for (const group of memberGroups) {
+            await expect(page.getByRole('heading', { name: group.name, level: 3 })).toBeVisible();
+        }
+    });
 
-  test('グループカードをクリックして出席履歴を展開・折りたたみできること', async ({ page }) => {
-    const index = await fetchIndex();
-    const member = selectMember(index, 2);
-    const memberGroups = member ? getMemberGroups(index, member) : [];
-    if (!member || memberGroups.length < 2) {
-      throw new Error('複数グループのメンバーが必要です');
-    }
-    await navigateTo(page, `/#/members/${member.id}`);
+    test('グループカードをクリックして出席履歴を展開・折りたたみできること', async ({ page }) => {
+        const index = await fetchIndex();
+        const member = selectMember(index, 2);
+        const memberGroups = member ? getMemberGroups(index, member) : [];
+        if (!member || memberGroups.length < 2) {
+            throw new Error('複数グループのメンバーが必要です');
+        }
+        await navigateTo(page, `/#/members/${member.id}`);
 
-    // メンバー名が表示される（画面準備完了を確認）
-    await expect(
-      page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
-    ).toBeVisible();
+        // メンバー名が表示される（画面準備完了を確認）
+        await expect(
+            page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
+        ).toBeVisible();
 
-    // 初期状態では出席履歴テーブルが表示されていない（複数グループなので折りたたみ）
-    await expect(page.getByRole('heading', { name: memberGroups[0].name, level: 3 })).toBeVisible();
-    const attendanceSection = page.locator('[data-section="attendance"]');
-    const expandedTables = attendanceSection.locator('.accordion-panel[data-expanded="true"] table');
-    await expect(expandedTables).toHaveCount(0);
+        // 初期状態では出席履歴テーブルが表示されていない（複数グループなので折りたたみ）
+        await expect(
+            page.getByRole('heading', { name: memberGroups[0].name, level: 3 })
+        ).toBeVisible();
+        const attendanceSection = page.locator('[data-section="attendance"]');
+        const expandedTables = attendanceSection.locator(
+            '.accordion-panel[data-expanded="true"] table'
+        );
+        await expect(expandedTables).toHaveCount(0);
 
-    // 「フロントエンド勉強会」カードをクリックして展開
-    await page.getByRole('heading', { name: memberGroups[0].name, level: 3 }).click();
-    await expect(expandedTables).toHaveCount(1);
+        // 「フロントエンド勉強会」カードをクリックして展開
+        await page.getByRole('heading', { name: memberGroups[0].name, level: 3 }).click();
+        await expect(expandedTables).toHaveCount(1);
 
-    // テーブルに日付列と参加時間列がある
-    const expandedPanel = attendanceSection.locator('.accordion-panel[data-expanded="true"]').first();
-    await expect(expandedPanel.getByRole('columnheader', { name: '日付' })).toBeVisible();
-    await expect(expandedPanel.getByRole('columnheader', { name: '参加時間' })).toBeVisible();
+        // テーブルに日付列と参加時間列がある
+        const expandedPanel = attendanceSection
+            .locator('.accordion-panel[data-expanded="true"]')
+            .first();
+        await expect(expandedPanel.getByRole('columnheader', { name: '日付' })).toBeVisible();
+        await expect(expandedPanel.getByRole('columnheader', { name: '参加時間' })).toBeVisible();
 
-    // 再クリックで折りたたみ
-    await page.getByRole('heading', { name: memberGroups[0].name, level: 3 }).click();
-    await expect(expandedTables).toHaveCount(0);
-  });
+        // 再クリックで折りたたみ
+        await page.getByRole('heading', { name: memberGroups[0].name, level: 3 }).click();
+        await expect(expandedTables).toHaveCount(0);
+    });
 
-  test('グループが1つのみのメンバーでも初期状態でアコーディオンが閉じていること', async ({ page }) => {
-    const index = await fetchIndex();
-    const member = index.members.find(
-      (candidate) => getMemberGroups(index, candidate).length === 1
-    );
-    if (!member) {
-      throw new Error('単一グループのメンバーが必要です');
-    }
-    const memberGroups = getMemberGroups(index, member);
-    await navigateTo(page, `/#/members/${member.id}`);
+    test('グループが1つのみのメンバーでも初期状態でアコーディオンが閉じていること', async ({
+        page,
+    }) => {
+        const index = await fetchIndex();
+        const member = index.members.find(
+            (candidate) => getMemberGroups(index, candidate).length === 1
+        );
+        if (!member) {
+            throw new Error('単一グループのメンバーが必要です');
+        }
+        const memberGroups = getMemberGroups(index, member);
+        await navigateTo(page, `/#/members/${member.id}`);
 
-    // グループ名が表示される（画面準備完了を確認）
-    await expect(page.getByRole('heading', { name: memberGroups[0].name, level: 3 })).toBeVisible();
+        // グループ名が表示される（画面準備完了を確認）
+        await expect(
+            page.getByRole('heading', { name: memberGroups[0].name, level: 3 })
+        ).toBeVisible();
 
-    // 全アコーディオンがデフォルトで閉じている
-    await expect(page.locator('[data-section="attendance"] .accordion-panel[data-expanded="true"] table')).toHaveCount(0);
-  });
+        // 全アコーディオンがデフォルトで閉じている
+        await expect(
+            page.locator('[data-section="attendance"] .accordion-panel[data-expanded="true"] table')
+        ).toHaveCount(0);
+    });
 
-  test('複数のグループカードを同時に展開できること', async ({ page }) => {
-    const index = await fetchIndex();
-    const member = selectMember(index, 2);
-    const memberGroups = member ? getMemberGroups(index, member) : [];
-    if (!member || memberGroups.length < 2) {
-      throw new Error('複数グループのメンバーが必要です');
-    }
-    await navigateTo(page, `/#/members/${member.id}`);
+    test('講師回数を持つメンバーで講師履歴セクションが表示されること', async ({ page }) => {
+        const index = await fetchIndex();
+        // instructorCount > 0 のメンバー（Suzuki Taro A）に遷移
+        const member = index.members.find((m) => (m.instructorCount ?? 0) > 0);
+        if (!member) {
+            throw new Error('講師回数を持つメンバーが存在しないためテストできません');
+        }
+        await navigateTo(page, `/#/members/${member.id}`);
 
-    // メンバー名が表示される（画面準備完了を確認）
-    await expect(
-      page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
-    ).toBeVisible();
+        // メンバー名が表示される（画面準備完了を確認）
+        await expect(
+            page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
+        ).toBeVisible();
 
-    // 2つのグループを展開
-    await page.getByRole('heading', { name: memberGroups[0].name, level: 3 }).click();
-    await page.getByRole('heading', { name: memberGroups[1].name, level: 3 }).click();
+        // ヘッダーに「講師」テキストが表示されること
+        await expect(page.getByText('講師').first()).toBeVisible();
 
-    // 2つのテーブルが表示される
-    await expect(page.locator('[data-section="attendance"] .accordion-panel[data-expanded="true"] table')).toHaveCount(2);
-  });
+        // 講師履歴セクションが表示されること
+        const instructorSection = page.locator('[data-section="instructor"]');
+        await expect(instructorSection).toBeVisible();
+        await expect(instructorSection.getByText('講師履歴')).toBeVisible();
+    });
+
+    test('出席履歴のグループヘッダーに主催者名が表示されること', async ({ page }) => {
+        const index = await fetchIndex();
+        const organizerMap = new Map((index.organizers ?? []).map((o) => [o.id, o.name]));
+        // 主催者ありのグループに参加しているメンバーを選択
+        const groupsWithOrganizer = index.groups.filter(
+            (g) => g.organizerId && organizerMap.has(g.organizerId)
+        );
+        const member = index.members.find((m) =>
+            groupsWithOrganizer.some((g) =>
+                g.sessionRevisions.some((ref) => m.sessionRevisions.includes(ref))
+            )
+        );
+        if (!member) {
+            throw new Error(
+                '主催者ありグループに参加しているメンバーが存在しないためテストできません'
+            );
+        }
+        await navigateTo(page, `/#/members/${member.id}`);
+
+        // メンバー名が表示される（画面準備完了を確認）
+        await expect(
+            page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
+        ).toBeVisible();
+
+        // 出席履歴セクション内に主催者名テキストが表示されること
+        const attendanceSection = page.locator('[data-section="attendance"]');
+        await expect(attendanceSection).toBeVisible();
+        // 主催者名のいずれかが出席履歴セクション内に表示されていること
+        const organizerNames = groupsWithOrganizer.map((g) => organizerMap.get(g.organizerId));
+        let foundOrganizer = false;
+        for (const name of organizerNames) {
+            const count = await attendanceSection.getByText(name).count();
+            if (count > 0) {
+                foundOrganizer = true;
+                break;
+            }
+        }
+        expect(foundOrganizer).toBe(true);
+    });
+
+    test('複数のグループカードを同時に展開できること', async ({ page }) => {
+        const index = await fetchIndex();
+        const member = selectMember(index, 2);
+        const memberGroups = member ? getMemberGroups(index, member) : [];
+        if (!member || memberGroups.length < 2) {
+            throw new Error('複数グループのメンバーが必要です');
+        }
+        await navigateTo(page, `/#/members/${member.id}`);
+
+        // メンバー名が表示される（画面準備完了を確認）
+        await expect(
+            page.getByRole('heading', { name: new RegExp(escapeRegExp(member.name)) })
+        ).toBeVisible();
+
+        // 2つのグループを展開
+        await page.getByRole('heading', { name: memberGroups[0].name, level: 3 }).click();
+        await page.getByRole('heading', { name: memberGroups[1].name, level: 3 }).click();
+
+        // 2つのテーブルが表示される
+        await expect(
+            page.locator('[data-section="attendance"] .accordion-panel[data-expanded="true"] table')
+        ).toHaveCount(2);
+    });
 });


### PR DESCRIPTION
## Summary

Closes #180

講師（Instructor）と主催者（Organizer）機能に対する E2E テスト 9 件を追加しました。

### 追加テスト一覧

**`e2e/dashboard.spec.js` — 表示テスト 6 件（readonly）:**
- グループ一覧に主催者名が表示されること
- メンバー一覧に講師回数が表示されること
- グループ詳細画面のヘッダーに主催者名が表示されること
- セッション一覧に講師名が表示されること
- 講師回数を持つメンバーで講師履歴セクションが表示されること
- 出席履歴のグループヘッダーに主催者名が表示されること

**`e2e/admin-group-edit.spec.js` — 管理画面 readonly テスト 1 件:**
- グループを展開すると主催者セクションが表示されること

**`e2e/admin-dev-mode.spec.js` — データ変更テスト 2 件:**
- token=dev でグループに主催者を設定して保存できること
- token=dev でセッションの講師を変更して保存できること
- afterEach の復元条件に上記 2 テストを追加

## Test plan

- [x] `npx playwright test` で全 40 テストが合格することを確認済み
- [ ] CI の E2E テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)